### PR TITLE
PLA-837 update cronjob to pull valuations once a month

### DIFF
--- a/charts/devices-api/templates/cronjob.yaml
+++ b/charts/devices-api/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "devices-api.fullname" . }}-load-dd
+  name: {{ include "devices-api.fullname" . }}-jobs
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "devices-api.labels" . | nindent 4 }}
@@ -21,12 +21,12 @@ spec:
             {{- include "devices-api.selectorLabels" . | nindent 12 }}
         spec:
           containers:
-          - name: edmunds-vehicles-sync
+          - name: valuations-pull
             securityContext:
               {{- toYaml .Values.securityContext | nindent 14 }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             command: ['/bin/sh']
-            args: ['-c', '/devices-api smartcar-sync; CODE=$?; echo "smartcar-sync completed"; wget -q --post-data "hello=shutdown" http://localhost:4191/shutdown; exit $CODE;']
+            args: ['-c', '/devices-api valuations-pull; CODE=$?; echo "valuations-pull completed"; wget -q --post-data "hello=shutdown" http://localhost:4191/shutdown; exit $CODE;']
             envFrom:
             - configMapRef:
                 name: {{ include "devices-api.fullname" . }}-config

--- a/charts/devices-api/values-prod.yaml
+++ b/charts/devices-api/values-prod.yaml
@@ -4,8 +4,8 @@ image:
   pullPolicy: IfNotPresent
   tag: 1.11.4
 cronJob:
-  enabled: false
-  schedule: 0 0 * * 0
+  enabled: true
+  schedule: 0 0 1 * *
 env:
   ENVIRONMENT: prod
   PORT: '8080'


### PR DESCRIPTION
# Proposed Changes
- remove smartcar sync (this command does not exist anymore, would likely cause problems running it)
- rename cronjob stuff to make more sense
- run valuations pull once a month

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->