### PR TITLE
PLA-1033 prioritize by odometer for device status

### DIFF
--- a/cmd/devices-api/api.go
+++ b/cmd/devices-api/api.go
@@ -179,11 +179,12 @@ func startWebAPI(logger zerolog.Logger, settings *config.Settings, pdb db.Store,
 	v1Auth.Get("/user/devices/:userDeviceID/valuations", userDeviceController.GetValuations)
 	v1Auth.Get("/user/devices/:userDeviceID/offers", userDeviceController.GetOffers)
 	v1Auth.Get("/user/devices/:userDeviceID/range", userDeviceController.GetRange)
+	v1Auth.Get("/user/devices/:userDeviceID/status", userDeviceController.GetUserDeviceStatus)
+
 	// device integrations
 	v1Auth.Get("/user/devices/:userDeviceID/integrations/:integrationID", userDeviceController.GetUserDeviceIntegration)
 	v1Auth.Delete("/user/devices/:userDeviceID/integrations/:integrationID", userDeviceController.DeleteUserDeviceIntegration)
 	v1Auth.Post("/user/devices/:userDeviceID/integrations/:integrationID", userDeviceController.RegisterDeviceIntegration)
-	v1Auth.Get("/user/devices/:userDeviceID/status", userDeviceController.GetUserDeviceStatus)
 	v1Auth.Post("/user/devices/:userDeviceID/commands/refresh", userDeviceController.RefreshUserDeviceStatus)
 
 	// Device commands.

--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -18,7 +18,7 @@ import (
 
 func PrepareDeviceStatusInformation(deviceData models.UserDeviceDatumSlice, privilegeIDs []int64) DeviceSnapshot {
 	ds := DeviceSnapshot{}
-	// order the records by odometer asc if they both have it, the latter one replaces
+	// order the records by odometer asc so that if they both have it, the latter one replaces with more recent values.
 	sortByJSONOdometerAsc(deviceData)
 
 	// merging data: foreach order by updatedAt desc, only set property if it exists in json data
@@ -236,7 +236,6 @@ func sortByJSONOdometerAsc(udd models.UserDeviceDatumSlice) {
 		} else if !fpri.Exists() && fprj.Exists() {
 			return false
 		}
-		// todo test for below to validate right way
 		return fprj.Float() > fpri.Float()
 	})
 }


### PR DESCRIPTION
# Proposed Changes
- sort the user_device_data by odometer asc so that when merging data from autopi and smartcar, even if smartcar data says it is newer we actually use the newest data, which is determined by the highest odometer

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->
`/user/devices/{udid}/status`
### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->