### PR TITLE
PLA-1054 add range calculation if it is not in data from ingest

### DIFF
--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -1,8 +1,10 @@
 package controllers
 
 import (
+	"context"
 	"database/sql"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/DIMO-Network/devices-api/internal/constants"
@@ -114,6 +116,45 @@ func PrepareDeviceStatusInformation(deviceData models.UserDeviceDatumSlice, priv
 	return ds
 }
 
+// calculateRange returns the current estimated range based on fuel tank capacity, mpg, and fuelPercentRemaining and returns it in Kilometers
+func (udc *UserDevicesController) calculateRange(ctx context.Context, deviceDefinitionID string, fuelPercentRemaining float64) (*float64, error) {
+	if fuelPercentRemaining == 0 {
+		return nil, errors.New("fuelPercentRemaining is 0 so cannot calculate range")
+	}
+	dd, err := udc.DeviceDefSvc.GetDeviceDefinitionByID(ctx, deviceDefinitionID)
+	if err != nil {
+		return nil, helpers.GrpcErrorToFiber(err, "deviceDefSvc error getting definition id: "+deviceDefinitionID)
+	}
+	if dd != nil && dd.DeviceAttributes != nil {
+		// pull out device attribute values needed for calc
+		var fuelTankCapGal, mpg float64 //mpgHwy
+		for _, attr := range dd.DeviceAttributes {
+			switch attr.Name {
+			case "fuel_tank_capacity_gal":
+				if v, err := strconv.ParseFloat(attr.Value, 32); err == nil {
+					fuelTankCapGal = v
+				}
+			case "mpg":
+				if v, err := strconv.ParseFloat(attr.Value, 32); err == nil {
+					mpg = v
+				}
+				//case "mpg_highway":
+				//	if v, err := strconv.ParseFloat(attr.Value, 32); err == nil {
+				//		mpgHwy = v
+				//	}
+			}
+		}
+		// calculate, convert to Km
+		if fuelTankCapGal > 0 && mpg > 0 {
+			fuelTankAtGal := fuelTankCapGal * fuelPercentRemaining
+			rangeMiles := mpg * fuelTankAtGal
+			rangeKm := 1.60934 * rangeMiles
+			return &rangeKm, nil
+		}
+	}
+	return nil, nil
+}
+
 // GetUserDeviceStatus godoc
 // @Description Returns the latest status update for the device. May return 404 if the
 // @Description user does not have a device with the ID, or if no status updates have come
@@ -144,8 +185,15 @@ func (udc *UserDevicesController) GetUserDeviceStatus(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	// how should we handle the errorData, if at all?
 	ds := PrepareDeviceStatusInformation(deviceData, []int64{NonLocationData, CurrentLocation, AllTimeLocation})
+	if len(deviceData) > 0 && ds.Range == nil && ds.FuelPercentRemaining != nil {
+		rge, err := udc.calculateRange(c.Context(), userDevice.DeviceDefinitionID, *ds.FuelPercentRemaining)
+		if err != nil {
+			//just log
+			udc.log.Warn().Err(err).Str("deviceDefinitionID", userDevice.DeviceDefinitionID).Msg("could not get range")
+		}
+		ds.Range = rge
+	}
 
 	return c.JSON(ds)
 }

--- a/internal/controllers/device_data_controller_test.go
+++ b/internal/controllers/device_data_controller_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/DIMO-Network/device-definitions-api/pkg/grpc"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	"io"
 	"os"
@@ -144,4 +146,41 @@ func Test_sortByJSONOdometerAsc(t *testing.T) {
 	sortByJSONOdometerAsc(udd)
 	assert.Equal(t, float64(90), gjson.GetBytes(udd[0].Data.JSON, "odometer").Float())
 	assert.Equal(t, float64(100), gjson.GetBytes(udd[1].Data.JSON, "odometer").Float())
+}
+
+func TestUserDevicesController_calculateRange(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	logger := zerolog.New(os.Stdout).With().
+		Timestamp().
+		Str("app", "devices-api").
+		Logger()
+	ctx := context.Background()
+	deviceDefSvc := mock_services.NewMockDeviceDefinitionService(mockCtrl)
+
+	ddId := ksuid.New().String()
+	attrs := []*grpc.DeviceTypeAttribute{
+		{
+			Name:  "fuel_tank_capacity_gal",
+			Value: "15",
+		},
+		{
+			Name:  "mpg",
+			Value: "20",
+		},
+	}
+	deviceDefSvc.EXPECT().GetDeviceDefinitionByID(gomock.Any(), ddId).Times(1).Return(&grpc.GetDeviceDefinitionItemResponse{
+		DeviceDefinitionId: ddId,
+		Verified:           true,
+		DeviceAttributes:   attrs,
+	}, nil)
+
+	c := NewUserDevicesController(&config.Settings{Port: "3000"}, nil, &logger, deviceDefSvc, nil, &fakeEventService{},
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil)
+	rge, err := c.calculateRange(ctx, ddId, .70)
+	require.NoError(t, err)
+	require.NotNil(t, rge)
+	assert.Equal(t, 337.9614, *rge)
 }


### PR DESCRIPTION
# Proposed Changes

The range in user_device_data.data comes from the ingest. It is only present from SmartCar connected vehicles. Thanks to having fuel tank size and mpg for many vehicles, we can calculate this after the fact. 
If range in data is empty, then calculate on the fly using current fuel percent remaining - this should show range for many autopi customers. 

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->
`/user/devices/:userDeviceID/status`

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->