### PR TITLE
PLA-1118 close loopholes in /fromsmartcar endpoint

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -75,3 +75,7 @@ type Settings struct {
 	OpenAISecretKey                   string      `yaml:"OPENAI_SECRET_KEY"`
 	ChatGPTURL                        string      `yaml:"CHATGPT_URL"`
 }
+
+func (s *Settings) IsProduction() bool {
+	return s.Environment == "prod" // this string is set in the helm chart values-prod.yaml
+}

--- a/internal/controllers/device_data_controller_test.go
+++ b/internal/controllers/device_data_controller_test.go
@@ -70,7 +70,7 @@ func TestUserDevicesController_GetUserDeviceStatus(t *testing.T) {
 		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 		smartCarInt := test.BuildIntegrationGRPC(constants.SmartCarVendor, 0, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Mach E", 2020, autoPiInteg)
-		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, pdb)
+		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 		const unitID = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
 		const deviceID = "device123"
 		_ = test.SetupCreateAutoPiUnit(t, testUserID, unitID, func(s string) *string { return &s }(deviceID), pdb)
@@ -267,7 +267,7 @@ func TestUserDevicesController_QueryDeviceErrorCodes(t *testing.T) {
 
 		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
-		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, pdb)
+		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
 		mockDeps.deviceDefSvc.
 			EXPECT().
@@ -335,7 +335,7 @@ func TestUserDevicesController_ShouldErrorOnTooManyErrorCodes(t *testing.T) {
 
 		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
-		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, pdb)
+		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
 		mockDeps.deviceDefSvc.
 			EXPECT().
@@ -399,7 +399,7 @@ func TestUserDevicesController_ShouldErrorInvalidErrorCodes(t *testing.T) {
 
 		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
-		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, pdb)
+		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
 		mockDeps.deviceDefSvc.
 			EXPECT().
@@ -463,7 +463,7 @@ func TestUserDevicesController_ShouldErrorOnEmptyErrorCodes(t *testing.T) {
 
 		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
-		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, pdb)
+		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
 		mockDeps.deviceDefSvc.
 			EXPECT().
@@ -527,7 +527,7 @@ func TestUserDevicesController_ShouldStoreErrorCodeResponse(t *testing.T) {
 
 		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
-		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, pdb)
+		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
 		mockDeps.deviceDefSvc.
 			EXPECT().
@@ -595,7 +595,7 @@ func TestUserDevicesController_GetUserDevicesErrorCodeQueries(t *testing.T) {
 
 		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
-		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, pdb)
+		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
 		erCodes := []string{"P0017", "P0016"}
 

--- a/internal/controllers/geofences_controller_test.go
+++ b/internal/controllers/geofences_controller_test.go
@@ -118,7 +118,7 @@ func (s *GeofencesControllerTestSuite) TestPostGeofence() {
 	c := NewGeofencesController(&config.Settings{Port: "3000"}, s.pdb.DBS, s.logger, producer, s.deviceDefSvc)
 	app := fiber.New()
 	app.Post("/user/geofences", test.AuthInjectorTestHandler(injectedUserID), c.Create)
-	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, ksuid.New().String(), nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, ksuid.New().String(), nil, "", s.pdb)
 	req := CreateGeofence{
 		Name:          "Home",
 		Type:          "PrivacyFence",
@@ -162,7 +162,7 @@ func (s *GeofencesControllerTestSuite) TestPostGeofence400IfSameName() {
 	c := NewGeofencesController(&config.Settings{Port: "3000"}, s.pdb.DBS, s.logger, nil, s.deviceDefSvc)
 	app := fiber.New()
 	app.Post("/user/geofences", test.AuthInjectorTestHandler(injectedUserID), c.Create)
-	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, ksuid.New().String(), nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, ksuid.New().String(), nil, "", s.pdb)
 	test.SetupCreateGeofence(s.T(), injectedUserID, "Home", &ud, s.pdb)
 
 	req := CreateGeofence{
@@ -181,7 +181,7 @@ func (s *GeofencesControllerTestSuite) TestPostGeofence400IfNotYourDevice() {
 	app := fiber.New()
 	app.Post("/user/geofences", test.AuthInjectorTestHandler(injectedUserID), c.Create)
 	otherUserID := "7734"
-	ud := test.SetupCreateUserDevice(s.T(), otherUserID, ksuid.New().String(), nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), otherUserID, ksuid.New().String(), nil, "", s.pdb)
 
 	req := CreateGeofence{
 		Name:          "Home",
@@ -201,7 +201,7 @@ func (s *GeofencesControllerTestSuite) TestGetAllUserGeofences() {
 	app.Get("/user/geofences", test.AuthInjectorTestHandler(injectedUserID), c.GetAll)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "escaped", 2020, nil)
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionsByIDs(gomock.Any(), []string{dd[0].DeviceDefinitionId}).Return(dd, nil)
-	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	test.SetupCreateGeofence(s.T(), injectedUserID, "Home", &ud, s.pdb)
 
 	request, _ := http.NewRequest("GET", "/user/geofences", nil)
@@ -226,7 +226,7 @@ func (s *GeofencesControllerTestSuite) TestPutGeofence() {
 
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "escaped", 2020, nil)
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionsByIDs(gomock.Any(), []string{dd[0].DeviceDefinitionId}).Return(dd, nil)
-	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	gf := test.SetupCreateGeofence(s.T(), injectedUserID, "something", &ud, s.pdb)
 
 	// The fence is being detached from the device and it has type TriggerEntry anyway.
@@ -266,7 +266,7 @@ func (s *GeofencesControllerTestSuite) TestDeleteGeofence() {
 	c := NewGeofencesController(&config.Settings{Port: "3000"}, s.pdb.DBS, s.logger, producer, s.deviceDefSvc)
 	app := fiber.New()
 	app.Delete("/user/geofences/:geofenceID", test.AuthInjectorTestHandler(injectedUserID), c.Delete)
-	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, ksuid.New().String(), nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, ksuid.New().String(), nil, "", s.pdb)
 	gf := test.SetupCreateGeofence(s.T(), injectedUserID, "something", &ud, s.pdb)
 
 	producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(checkForDeviceAndH3(ud.ID, []string{}))

--- a/internal/controllers/helpers/handlers.go
+++ b/internal/controllers/helpers/handlers.go
@@ -124,7 +124,7 @@ func GrpcErrorToFiber(err error, msgAppend string) error {
 }
 
 // ErrorHandler custom handler to log recovered errors using our logger and return json instead of string
-func ErrorHandler(c *fiber.Ctx, err error, logger zerolog.Logger, environment string) error {
+func ErrorHandler(c *fiber.Ctx, err error, logger zerolog.Logger, isProduction bool) error {
 	code := fiber.StatusInternalServerError // Default 500 statuscode
 
 	e, fiberTypeErr := err.(*fiber.Error)
@@ -140,7 +140,7 @@ func ErrorHandler(c *fiber.Ctx, err error, logger zerolog.Logger, environment st
 		Str("httpPath", c.Path()).
 		Msg("caught an error from http request")
 	// return an opaque error if we're in a higher level environment and we haven't specified an fiber type err.
-	if !fiberTypeErr && environment == "prod" {
+	if !fiberTypeErr && isProduction {
 		err = fiber.NewError(fiber.StatusInternalServerError, "Internal error")
 	}
 

--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -553,7 +553,7 @@ func (udc *UserDevicesController) RegisterDeviceForUserFromSmartcar(c *fiber.Ctx
 	if err != nil {
 		return errors.Wrap(err, "failed to encrypt smartcar token json")
 	}
-	udc.redisCache.Set(c.Context(), buildSmartcarTokenKey(vin), encToken, time.Hour*2)
+	udc.redisCache.Set(c.Context(), buildSmartcarTokenKey(vin, userID), encToken, time.Hour*2)
 
 	// decode VIN with grpc call
 	decodeVIN, err := udc.DeviceDefSvc.DecodeVIN(c.Context(), vin)
@@ -584,8 +584,8 @@ func (udc *UserDevicesController) RegisterDeviceForUserFromSmartcar(c *fiber.Ctx
 	})
 }
 
-func buildSmartcarTokenKey(vin string) string {
-	return fmt.Sprintf("sc-temp-tok-%s", vin)
+func buildSmartcarTokenKey(vin, userID string) string {
+	return fmt.Sprintf("sc-temp-tok-%s-%s", vin, userID)
 }
 
 func (udc *UserDevicesController) createUserDevice(ctx context.Context, deviceDefID, countryCode, userID string, vin *string) (*UserDeviceFull, error) {

--- a/internal/controllers/user_devices_controller_test.go
+++ b/internal/controllers/user_devices_controller_test.go
@@ -152,7 +152,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar() {
 	}, nil)
 	s.deviceDefIntSvc.EXPECT().CreateDeviceDefinitionIntegration(gomock.Any(), "22N2xaPOq2WW2gAHBHd0Ikn4Zob", dd[0].DeviceDefinitionId, "Americas").Times(1).
 		Return(nil, nil)
-	s.redisClient.EXPECT().Set(gomock.Any(), buildSmartcarTokenKey(vinny), gomock.Any(), time.Hour*2).Return(nil)
+	s.redisClient.EXPECT().Set(gomock.Any(), buildSmartcarTokenKey(vinny, testUserID), gomock.Any(), time.Hour*2).Return(nil)
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionByID(gomock.Any(), dd[0].DeviceDefinitionId).Times(1).Return(dd[0], nil)
 	request := test.BuildRequest("POST", "/user/devices/fromsmartcar", string(j))
 	response, responseError := s.app.Test(request)

--- a/internal/controllers/user_devices_controller_test.go
+++ b/internal/controllers/user_devices_controller_test.go
@@ -86,7 +86,7 @@ func (s *UserDevicesControllerTestSuite) SetupSuite() {
 
 	s.testUserID = "123123"
 	testUserID2 := "3232451"
-	c := NewUserDevicesController(&config.Settings{Port: "3000"}, s.pdb.DBS, logger, s.deviceDefSvc, s.deviceDefIntSvc, &fakeEventService{}, s.scClient, s.scTaskSvc, teslaSvc, teslaTaskService, new(shared.ROT13Cipher), nil,
+	c := NewUserDevicesController(&config.Settings{Port: "3000", Environment: "prod"}, s.pdb.DBS, logger, s.deviceDefSvc, s.deviceDefIntSvc, &fakeEventService{}, s.scClient, s.scTaskSvc, teslaSvc, teslaTaskService, new(shared.ROT13Cipher), nil,
 		s.nhtsaService, autoPiIngest, deviceDefinitionIngest, autoPiTaskSvc, nil, nil, s.drivlyTaskSvc, nil, s.redisClient, nil)
 	app := test.SetupAppFiber(*logger)
 	app.Post("/user/devices", test.AuthInjectorTestHandler(s.testUserID), c.RegisterDeviceForUser)
@@ -180,6 +180,37 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar() {
 	assert.NotNilf(s.T(), userDevice, "expected a user device in the database to exist")
 	assert.Equal(s.T(), s.testUserID, userDevice.UserID)
 	assert.Equal(s.T(), vinny, userDevice.VinIdentifier.String)
+}
+
+func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_DuplicateVIN() {
+	// arrange DB
+	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
+
+	// act request
+	const vinny = "4T3R6RFVXMU023395"
+	reg := RegisterUserDeviceSmartcar{Code: "XX", RedirectURI: "https://mobile-app", CountryCode: "USA"}
+	j, _ := json.Marshal(reg)
+	test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, vinny, s.pdb)
+
+	s.scClient.EXPECT().ExchangeCode(gomock.Any(), reg.Code, reg.RedirectURI).Times(1).Return(&smartcar.Token{
+		Access:        "AA",
+		AccessExpiry:  time.Now().Add(time.Hour),
+		Refresh:       "RR",
+		RefreshExpiry: time.Now().Add(time.Hour),
+		ExpiresIn:     3600,
+	}, nil)
+	s.scClient.EXPECT().GetExternalID(gomock.Any(), "AA").Times(1).Return("123", nil)
+	s.scClient.EXPECT().GetVIN(gomock.Any(), "AA", "123").Times(1).Return(vinny, nil)
+
+	request := test.BuildRequest("POST", "/user/devices/fromsmartcar", string(j))
+	response, responseError := s.app.Test(request)
+	fmt.Println(responseError)
+	body, _ := io.ReadAll(response.Body)
+	// assert
+	if assert.Equal(s.T(), fiber.StatusConflict, response.StatusCode) == false {
+		fmt.Println("message: " + string(body))
+	}
 }
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN() {
@@ -321,7 +352,7 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevices() {
 	// arrange db, insert some user_devices
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	const (
 		unitID   = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
 		deviceID = "device123"
@@ -352,7 +383,7 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevices() {
 func (s *UserDevicesControllerTestSuite) TestPatchVIN() {
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 4)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Escape", 2020, integration)
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	s.deviceDefSvc.EXPECT().GetIntegrations(gomock.Any()).Return([]*grpc.Integration{integration}, nil)
 
 	evID := "4"
@@ -460,7 +491,7 @@ func (s *UserDevicesControllerTestSuite) TestNameValidate() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPatchName() {
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ksuid.New().String(), nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ksuid.New().String(), nil, "", s.pdb)
 	// nil check test
 	payload := `{}`
 	request := test.BuildRequest("PATCH", "/user/devices/"+ud.ID+"/name", payload)
@@ -479,7 +510,7 @@ func (s *UserDevicesControllerTestSuite) TestPatchName() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPatchImageURL() {
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ksuid.New().String(), nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ksuid.New().String(), nil, "", s.pdb)
 
 	payload := `{ "imageUrl": "https://ipfs.com/planetary/car.jpg" }`
 	request := test.BuildRequest("PATCH", "/user/devices/"+ud.ID+"/image", payload)
@@ -502,7 +533,7 @@ var testVincarioValuationJSON string
 func (s *UserDevicesControllerTestSuite) TestGetDeviceValuations_Format1() {
 	// arrange db, insert some user_devices
 	ddID := ksuid.New().String()
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, "", s.pdb)
 	_ = test.SetupCreateExternalVINData(s.T(), ddID, &ud, map[string][]byte{
 		"PricingMetadata": []byte(testDrivlyPricingJSON),
 	}, s.pdb)
@@ -530,7 +561,7 @@ func (s *UserDevicesControllerTestSuite) TestGetDeviceValuations_Format2() {
 	// this is the other format we're seeing coming from drivly for pricing
 	// arrange db, insert some user_devices
 	ddID := ksuid.New().String()
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, "", s.pdb)
 	_ = test.SetupCreateExternalVINData(s.T(), ddID, &ud, map[string][]byte{
 		"PricingMetadata": []byte(testDrivlyPricing2JSON),
 	}, s.pdb)
@@ -552,7 +583,7 @@ func (s *UserDevicesControllerTestSuite) TestGetDeviceValuations_Vincario() {
 	// this is the other format we're seeing coming from drivly for pricing
 	// arrange db, insert some user_devices
 	ddID := ksuid.New().String()
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, "", s.pdb)
 	_ = test.SetupCreateExternalVINData(s.T(), ddID, &ud, map[string][]byte{
 		"VincarioMetadata": []byte(testVincarioValuationJSON),
 	}, s.pdb)
@@ -581,7 +612,7 @@ var testDrivlyOffersJSON string
 func (s *UserDevicesControllerTestSuite) TestGetDeviceOffers() {
 	// arrange db, insert some user_devices
 	ddID := ksuid.New().String()
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, "", s.pdb)
 	_ = test.SetupCreateExternalVINData(s.T(), ddID, &ud, map[string][]byte{
 		"OfferMetadata": []byte(testDrivlyOffersJSON),
 		// "PricingMetadata":   nil,
@@ -630,7 +661,7 @@ func (s *UserDevicesControllerTestSuite) TestGetRange() {
 			DeviceDefinitionId: ddID,
 		},
 	}
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, ddID, nil, "", s.pdb)
 	test.SetupCreateUserDeviceAPIIntegration(s.T(), autoPiUnitID, autoPiDeviceID, ud.ID, integration.Id, s.pdb)
 	udd := models.UserDeviceDatum{
 		UserDeviceID:  ud.ID,
@@ -672,7 +703,7 @@ func (s *UserDevicesControllerTestSuite) TestGetRange() {
 func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCar() {
 	smartCarInt := test.BuildIntegrationGRPC(constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Escape", 2020, smartCarInt)
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	s.deviceDefSvc.EXPECT().GetIntegrationByVendor(gomock.Any(), constants.SmartCarVendor).Return(smartCarInt, nil)
 	// arrange some additional data for this to work
 
@@ -724,7 +755,7 @@ func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCar() {
 func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCarRateLimited() {
 	integration := test.BuildIntegrationGRPC(constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Mache", 2022, integration)
-	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	s.deviceDefSvc.EXPECT().GetIntegrationByVendor(gomock.Any(), constants.SmartCarVendor).Return(integration, nil)
 
 	udiai := models.UserDeviceAPIIntegration{

--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -1987,7 +1987,7 @@ func (udc *UserDevicesController) registerSmartcarIntegration(c *fiber.Ctx, logg
 	var token *smartcar.Token
 	// check for token in redis, if exists do not call this.
 	if ud.VinIdentifier.Valid {
-		scTokenGet, err := udc.redisCache.Get(c.Context(), buildSmartcarTokenKey(ud.VinIdentifier.String)).Result()
+		scTokenGet, err := udc.redisCache.Get(c.Context(), buildSmartcarTokenKey(ud.VinIdentifier.String, ud.UserID)).Result()
 		if err == nil && len(scTokenGet) > 0 {
 			decrypted, err := udc.cipher.Decrypt(scTokenGet)
 			if err != nil {
@@ -2000,7 +2000,7 @@ func (udc *UserDevicesController) registerSmartcarIntegration(c *fiber.Ctx, logg
 				udc.log.Err(err).Msgf("failed to unmarshal smartcar token found in redis cache for vin: %s", ud.VinIdentifier.String)
 			}
 			// clear cache
-			udc.redisCache.Del(c.Context(), buildSmartcarTokenKey(ud.VinIdentifier.String))
+			udc.redisCache.Del(c.Context(), buildSmartcarTokenKey(ud.VinIdentifier.String, ud.UserID))
 		}
 	}
 	if token == nil {

--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -2041,7 +2041,7 @@ func (udc *UserDevicesController) registerSmartcarIntegration(c *fiber.Ctx, logg
 
 	// Prevent users from connecting a vehicle if it's already connected through another user
 	// device object. Disabled outside of prod for ease of testing.
-	if udc.Settings.Environment == "prod" {
+	if udc.Settings.IsProduction() {
 		// Probably a race condition here. Need to either lock something or impose a greater
 		// isolation level.
 		conflict, err := models.UserDevices(

--- a/internal/controllers/user_integrations_controller_test.go
+++ b/internal/controllers/user_integrations_controller_test.go
@@ -136,7 +136,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetIntegrations() {
 func (s *UserIntegrationsControllerTestSuite) TestPostSmartCarFailure() {
 	integration := test.BuildIntegrationGRPC(constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Mach E", 2020, integration)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 
 	req := `{
 			"code": "qxyz",
@@ -162,7 +162,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessNewToken()
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", model, 2020, integration)
 	// corrected after query smartcar
 	dd2 := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", model, 2022, integration)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 
 	const smartCarUserID = "smartCarUserId"
 	req := `{
@@ -256,7 +256,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessCachedToke
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", model, 2020, integration)
 	// corrected after query smartcar
 	dd2 := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", model, 2022, integration)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	ud.VinIdentifier = null.StringFrom(vin)
 	ud.VinConfirmed = true
 	_, err := ud.Update(s.ctx, s.pdb.DBS().Writer, boil.Infer())
@@ -362,7 +362,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostUnknownDevice() {
 func (s *UserIntegrationsControllerTestSuite) TestPostTesla() {
 	integration := test.BuildIntegrationGRPC(constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model Y", 2020, integration)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 
 	oV := &services.TeslaVehicle{}
 	oUdai := &models.UserDeviceAPIIntegration{}
@@ -448,7 +448,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTeslaAndUpdateDD() {
 	integration := test.BuildIntegrationGRPC(constants.TeslaVendor, 10, 20)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Mach E", 2020, integration)
 
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 
 	s.deviceDefSvc.EXPECT().FindDeviceDefinitionByMMY(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dd[0], nil)
 
@@ -475,7 +475,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostAutoPiBlockedForDuplicateD
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 34, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model 4", 2020, integration)
 
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	const (
 		deviceID = "1dd96159-3bb2-9472-91f6-72fe9211cfeb"
 		unitID   = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
@@ -511,14 +511,14 @@ func (s *UserIntegrationsControllerTestSuite) TestPostAutoPiBlockedForDuplicateD
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 34, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model 4", 2022, nil)
 	// the other user that already claimed unit
-	_ = test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	_ = test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	const (
 		deviceID = "1dd96159-3bb2-9472-91f6-72fe9211cfeb"
 		unitID   = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
 	)
 	_ = test.SetupCreateAutoPiUnit(s.T(), testUserID, unitID, func(s string) *string { return &s }(deviceID), s.pdb)
 	// test user
-	ud2 := test.SetupCreateUserDevice(s.T(), testUser2, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud2 := test.SetupCreateUserDevice(s.T(), testUser2, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 
 	req := fmt.Sprintf(`{
 			"externalId": "%s"
@@ -545,7 +545,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostAutoPiCommand() {
 	// arrange
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 34, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model 4", 2022, nil)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	const (
 		deviceID = "1dd96159-3bb2-9472-91f6-72fe9211cfeb"
 		unitID   = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
@@ -609,7 +609,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetAutoPiCommand() {
 	//arrange
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 34, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model 4", 2022, nil)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	const (
 		deviceID = "1dd96159-3bb2-9472-91f6-72fe9211cfeb"
 		jobID    = "somepreviousjobId"
@@ -648,7 +648,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetAutoPiCommandNoResults400()
 	//arrange
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 34, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model 4", 2022, nil)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	const (
 		jobID    = "somepreviousjobId2"
 		deviceID = "1dd96159-3bb2-9472-91f6-72fe9211cfeb"
@@ -777,7 +777,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetAutoPiInfoNoMatchUDAI() {
 	const unitID = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 34, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model 4", 2022, nil)
-	ud := test.SetupCreateUserDevice(s.T(), "some-other-user", dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), "some-other-user", dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	_ = test.SetupCreateAutoPiUnit(s.T(), testUserID, unitID, func(s string) *string { return &s }("1234"), s.pdb)
 	test.SetupCreateUserDeviceAPIIntegration(s.T(), unitID, "321", ud.ID, integration.Id, s.pdb)
 

--- a/internal/controllers/user_integrations_controller_test.go
+++ b/internal/controllers/user_integrations_controller_test.go
@@ -281,8 +281,8 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessCachedToke
 	cipher := new(shared.ROT13Cipher)
 	encrypted, err := cipher.Encrypt(string(tokenJSON))
 	require.NoError(s.T(), err)
-	s.redisClient.EXPECT().Get(gomock.Any(), buildSmartcarTokenKey(vin)).Return(redis.NewStringResult(encrypted, nil))
-	s.redisClient.EXPECT().Del(gomock.Any(), buildSmartcarTokenKey(vin)).Return(redis.NewIntResult(1, nil))
+	s.redisClient.EXPECT().Get(gomock.Any(), buildSmartcarTokenKey(vin, testUserID)).Return(redis.NewStringResult(encrypted, nil))
+	s.redisClient.EXPECT().Del(gomock.Any(), buildSmartcarTokenKey(vin, testUserID)).Return(redis.NewIntResult(1, nil))
 	s.eventSvc.EXPECT().Emit(gomock.Any()).Return(nil).Do(
 		func(event *services.Event) error {
 			assert.Equal(s.T(), ud.ID, event.Subject)

--- a/internal/controllers/webhooks_controller_test.go
+++ b/internal/controllers/webhooks_controller_test.go
@@ -117,7 +117,7 @@ func (s *WebHooksControllerTestSuite) TestPostWebhookSyncCommand() {
 	autoPiJobID := "AD111"
 	integ := test.BuildIntegrationGRPC(constants.AutoPiVendor, autoPiTemplateID, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model X", 2020, integ)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	autopiJob := test.SetupCreateAutoPiJob(s.T(), autoPiJobID, autoPiDeviceID, "state.sls pending", ud.ID, "COMMAND_EXECUTED", "", s.pdb)
 
 	ddDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Return(integ, nil)
@@ -185,7 +185,7 @@ func (s *WebHooksControllerTestSuite) TestPostWebhookRawCommand() {
 	autoPiJobID := "AD111"
 	integ := test.BuildIntegrationGRPC(constants.AutoPiVendor, autoPiTemplateID, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model X", 2020, integ)
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	// create user device api integration
 	commandResult := `{ "value": "123", "type": "vin" }`
 

--- a/internal/services/autopi/integration_test.go
+++ b/internal/services/autopi/integration_test.go
@@ -89,7 +89,7 @@ func (s *IntegrationTestSuite) Test_Pair_With_DD_HardwareTemplate_Success() {
 	autoPiTokenID, _ := new(big.Int).SetString("0", 16)
 	vehicleTokenID, _ := new(big.Int).SetString("0", 16)
 
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, "", s.pdb)
 	autoPIUnit := test.SetupCreateAutoPiUnitWithToken(s.T(), testUserID, unitID, autoPiTokenID, &ud.ID, s.pdb)
 	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, s.pdb)
 
@@ -151,7 +151,7 @@ func (s *IntegrationTestSuite) Test_Pair_With_Make_HardwareTemplate_Success() {
 	autoPiTokenID, _ := new(big.Int).SetString("0", 16)
 	vehicleTokenID, _ := new(big.Int).SetString("0", 16)
 
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, "", s.pdb)
 	autoPIUnit := test.SetupCreateAutoPiUnitWithToken(s.T(), testUserID, unitID, autoPiTokenID, &ud.ID, s.pdb)
 	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, s.pdb)
 
@@ -213,7 +213,7 @@ func (s *IntegrationTestSuite) Test_Pair_With_DD_DeviceStyle_HardwareTemplate_Su
 	autoPiTokenID, _ := new(big.Int).SetString("0", 16)
 	vehicleTokenID, _ := new(big.Int).SetString("0", 16)
 
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, "", s.pdb)
 	autoPIUnit := test.SetupCreateAutoPiUnitWithToken(s.T(), testUserID, unitID, autoPiTokenID, &ud.ID, s.pdb)
 	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, s.pdb)
 
@@ -283,7 +283,7 @@ func (s *IntegrationTestSuite) Test_Pair_With_UserDeviceStyle_HardwareTemplate_S
 	autoPiTokenID, _ := new(big.Int).SetString("0", 16)
 	vehicleTokenID, _ := new(big.Int).SetString("0", 16)
 
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, "", s.pdb)
 	autoPIUnit := test.SetupCreateAutoPiUnitWithToken(s.T(), testUserID, unitID, autoPiTokenID, &ud.ID, s.pdb)
 	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, s.pdb)
 

--- a/internal/services/autopi_api_service_test.go
+++ b/internal/services/autopi_api_service_test.go
@@ -59,7 +59,7 @@ func (s *AutoPiAPIServiceTestSuite) TestGetUserDeviceIntegrationByUnitID() {
 	const testUserID = "123123"
 	autoPiUnitID := "456"
 
-	ud := test.SetupCreateUserDevice(s.T(), testUserID, ksuid.New().String(), nil, s.pdb)
+	ud := test.SetupCreateUserDevice(s.T(), testUserID, ksuid.New().String(), nil, "", s.pdb)
 
 	unit := &models.AutopiUnit{
 		AutopiUnitID: autoPiUnitID,

--- a/internal/services/device_status_ingest_service_test.go
+++ b/internal/services/device_status_ingest_service_test.go
@@ -90,7 +90,7 @@ func TestIngestDeviceStatus(t *testing.T) {
 	integrationID := integs[0].Id
 
 	ingest := NewDeviceStatusIngestService(pdb.DBS, &logger, mes, deviceDefSvc, autoPISvc)
-	ud := test.SetupCreateUserDevice(t, "dylan", ksuid.New().String(), nil, pdb)
+	ud := test.SetupCreateUserDevice(t, "dylan", ksuid.New().String(), nil, "", pdb)
 
 	udai := models.UserDeviceAPIIntegration{
 		UserDeviceID:  ud.ID,
@@ -209,7 +209,7 @@ func TestAutoPiStatusMerge(t *testing.T) {
 
 	ingest := NewDeviceStatusIngestService(pdb.DBS, &logger, mes, deviceDefSvc, autoPISvc)
 
-	ud := test.SetupCreateUserDevice(t, "dylan", ddID, nil, pdb)
+	ud := test.SetupCreateUserDevice(t, "dylan", ddID, nil, "", pdb)
 
 	udai := models.UserDeviceAPIIntegration{
 		UserDeviceID:  ud.ID,

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -142,7 +142,7 @@ func getTestDbSettings() config.Settings {
 func SetupAppFiber(logger zerolog.Logger) *fiber.App {
 	app := fiber.New(fiber.Config{
 		ErrorHandler: func(c *fiber.Ctx, err error) error {
-			return helpers.ErrorHandler(c, err, logger, "test")
+			return helpers.ErrorHandler(c, err, logger, false)
 		},
 	})
 	return app
@@ -191,13 +191,17 @@ func Logger() *zerolog.Logger {
 	return &l
 }
 
-func SetupCreateUserDevice(t *testing.T, testUserID string, ddID string, metadata *[]byte, pdb db.Store) models.UserDevice {
+func SetupCreateUserDevice(t *testing.T, testUserID string, ddID string, metadata *[]byte, vin string, pdb db.Store) models.UserDevice {
 	ud := models.UserDevice{
 		ID:                 ksuid.New().String(),
 		UserID:             testUserID,
 		DeviceDefinitionID: ddID,
 		CountryCode:        null.StringFrom("USA"),
 		Name:               null.StringFrom("Chungus"),
+	}
+	if len(vin) == 17 {
+		ud.VinIdentifier = null.StringFrom(vin)
+		ud.VinConfirmed = true
 	}
 	if metadata == nil {
 		// note cannot import enum from services


### PR DESCRIPTION
# Proposed Changes
- user id in redis cache key
- duplicate vin check

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->