### PR TITLE
PLA-1330 create device_integration on decoding vin from autopi

### DIFF
--- a/internal/controllers/user_devices_controller_test.go
+++ b/internal/controllers/user_devices_controller_test.go
@@ -266,6 +266,9 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN() {
 		Year:               dd[0].Type.Year,
 	}, nil)
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionByID(gomock.Any(), dd[0].DeviceDefinitionId).Times(1).Return(dd[0], nil)
+	apInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 10)
+	s.deviceDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Times(1).Return(apInteg, nil)
+	s.deviceDefIntSvc.EXPECT().CreateDeviceDefinitionIntegration(gomock.Any(), apInteg.Id, dd[0].DeviceDefinitionId, "Americas")
 	request := test.BuildRequest("POST", "/user/devices/fromvin", string(j))
 	response, responseError := s.app.Test(request)
 	fmt.Println(responseError)


### PR DESCRIPTION
# Proposed Changes
- we want to make sure a device_integration record gets created - fine if it already exists, when a vin is added via the endpoint that is called as part of the autopi initial pairing. 

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->