### PR TITLE
PLA-1316-devices-owned-by-addr

### DIFF
--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -290,6 +290,7 @@ func (udc *UserDevicesController) GetUserDevices(c *fiber.Ctx) error {
 	}
 
 	addr := common.Hex2Bytes(*user.EthereumAddress)
+	// TODO(AE): could reduce db calls with a nested select in UserDevices
 	devicesByNfts, err := models.VehicleNFTS(
 		qm.Select(models.VehicleNFTColumns.UserDeviceID),
 		models.VehicleNFTWhere.OwnerAddress.EQ(null.BytesFrom(addr)),

--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -282,7 +282,7 @@ func (udc *UserDevicesController) GetUserDevices(c *fiber.Ctx) error {
 
 	var query []qm.QueryMod
 
-	if user.EthereumAddress == nil {
+	if udc.Settings.IsProduction() || user.EthereumAddress == nil {
 		query = []qm.QueryMod{
 			models.UserDeviceWhere.UserID.EQ(userID),
 		}

--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/DIMO-Network/shared/redis"
-	"golang.org/x/exp/slices"
 
 	ddgrpc "github.com/DIMO-Network/device-definitions-api/pkg/grpc"
 	"github.com/DIMO-Network/devices-api/internal/config"
@@ -165,13 +164,7 @@ func (udc *UserDevicesController) dbDevicesToDisplay(ctx context.Context, device
 		return nil, helpers.GrpcErrorToFiber(err, "failed to get integrations")
 	}
 
-	seen := make([]string, 0)
 	for _, d := range devices {
-		if slices.Contains(seen, d.ID) {
-			continue
-		}
-		seen = append(seen, d.ID)
-
 		deviceDefinition, err := filterDeviceDefinition(d.DeviceDefinitionID, deviceDefinitionResponse)
 		if err != nil {
 			return nil, err
@@ -281,36 +274,32 @@ func (udc *UserDevicesController) dbDevicesToDisplay(ctx context.Context, device
 // @Security    BearerAuth
 // @Router      /user/devices/me [get]
 func (udc *UserDevicesController) GetUserDevices(c *fiber.Ctx) error {
-	// todo grpc call out to grpc service endpoint in the deviceDefinitionsService udc.deviceDefSvc.GetDeviceDefinitionsByIDs(c.Context(), []string{ "todo"} )
-
 	userID := helpers.GetUserID(c)
 	user, err := udc.usersClient.GetUser(c.Context(), &pb.GetUserRequest{Id: userID})
 	if err != nil {
 		return helpers.ErrorResponseHandler(c, err, fiber.StatusInternalServerError)
 	}
 
-	addr := common.Hex2Bytes(*user.EthereumAddress)
-	// TODO(AE): could reduce db calls with a nested select in UserDevices
-	devicesByNfts, err := models.VehicleNFTS(
-		qm.Select(models.VehicleNFTColumns.UserDeviceID),
-		models.VehicleNFTWhere.OwnerAddress.EQ(null.BytesFrom(addr)),
-	).All(c.Context(), udc.DBS().Reader)
-	if err != nil {
-		return helpers.ErrorResponseHandler(c, err, fiber.StatusInternalServerError)
+	var query []qm.QueryMod
+
+	if user.EthereumAddress == nil {
+		query = []qm.QueryMod{
+			models.UserDeviceWhere.UserID.EQ(userID),
+		}
+	} else {
+		query = []qm.QueryMod{
+			qm.LeftOuterJoin("devices_api." + models.TableNames.VehicleNFTS + " ON " + models.VehicleNFTColumns.UserDeviceID + " = " + models.UserDeviceColumns.ID),
+			models.UserDeviceWhere.UserID.EQ(userID),
+			qm.Or2(models.VehicleNFTWhere.OwnerAddress.EQ(null.BytesFrom(common.Hex2Bytes(*user.EthereumAddress)))),
+		}
 	}
 
-	ownedByAddr := make([]string, len(devicesByNfts))
-	for n, d := range devicesByNfts {
-		ownedByAddr[n] = d.UserDeviceID.String
-	}
-
-	devices, err := models.UserDevices(
-		models.UserDeviceWhere.UserID.EQ(userID),
-		qm.Or2(models.UserDeviceWhere.ID.IN(ownedByAddr)),
+	query = append(query,
 		qm.Load(models.UserDeviceRels.UserDeviceAPIIntegrations),
 		qm.Load(qm.Rels(models.UserDeviceRels.VehicleNFT, models.VehicleNFTRels.MintRequest)),
-		qm.OrderBy(models.UserDeviceColumns.CreatedAt),
-	).All(c.Context(), udc.DBS().Reader)
+		qm.OrderBy(models.UserDeviceColumns.CreatedAt+" DESC"))
+
+	devices, err := models.UserDevices(query...).All(c.Context(), udc.DBS().Reader)
 	if err != nil {
 		return helpers.ErrorResponseHandler(c, err, fiber.StatusInternalServerError)
 	}

--- a/internal/controllers/user_devices_controller_test.go
+++ b/internal/controllers/user_devices_controller_test.go
@@ -395,19 +395,26 @@ func (s *UserDevicesControllerTestSuite) TestPostInvalidDefinitionID() {
 
 func (s *UserDevicesControllerTestSuite) TestGetMyUserDevices() {
 	// arrange db, insert some user_devices
+	const (
+		// Device 1
+		unitID   = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
+		deviceID = "device1"
+
+		// Device 2
+		userID2   = "user2"
+		deviceID2 = "device2"
+	)
+
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
-	const (
-		unitID   = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
-		deviceID = "device123"
-	)
 	_ = test.SetupCreateAutoPiUnit(s.T(), testUserID, unitID, func(s string) *string { return &s }(deviceID), s.pdb)
 	_ = test.SetupCreateUserDeviceAPIIntegration(s.T(), unitID, deviceID, ud.ID, integration.Id, s.pdb)
 
 	addr := "67B94473D81D0cd00849D563C94d0432Ac988B49"
-	_ = test.SetupCreateUserDeviceWithID(s.T(), "userID2", "device2", dd[0].DeviceDefinitionId, nil, "", s.pdb)
-	_ = test.SetupCreateVehicleNFT(s.T(), "device2", "vin", big.NewInt(1), null.BytesFrom(common.Hex2Bytes(addr)), s.pdb)
+	_ = test.SetupCreateUserDeviceWithDeviceID(s.T(), userID2, deviceID2, dd[0].DeviceDefinitionId, nil, "", s.pdb)
+	_ = test.SetupCreateVehicleNFT(s.T(), deviceID2, "vin", big.NewInt(1), null.BytesFrom(common.Hex2Bytes(addr)), s.pdb)
+
 	s.usersClient.EXPECT().GetUser(gomock.Any(), &pb.GetUserRequest{Id: s.testUserID}).Return(&pb.User{Id: s.testUserID, EthereumAddress: &addr}, nil)
 	s.deviceDefSvc.EXPECT().GetIntegrations(gomock.Any()).Return([]*grpc.Integration{integration}, nil)
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionsByIDs(gomock.Any(), []string{dd[0].DeviceDefinitionId, dd[0].DeviceDefinitionId}).Times(1).Return(dd, nil)
@@ -418,19 +425,17 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevices() {
 	body, _ := io.ReadAll(response.Body)
 
 	assert.Equal(s.T(), fiber.StatusOK, response.StatusCode)
-
 	result := gjson.Get(string(body), "userDevices.#.id")
 	assert.Len(s.T(), result.Array(), 2)
 	for _, id := range result.Array() {
 		assert.True(s.T(), id.Exists(), "expected to find the ID")
-		if id.String() == s.testUserID {
-			assert.Equal(s.T(), ud.ID, id.String(), "expected user device ID to match")
-		}
 	}
-	assert.Equal(s.T(), integration.Id, gjson.GetBytes(body, "userDevices.0.integrations.0.integrationId").String())
-	assert.Equal(s.T(), "device123", gjson.GetBytes(body, "userDevices.0.integrations.0.externalId").String())
-	assert.Equal(s.T(), "device2                    ", gjson.GetBytes(body, "userDevices.1.id").String())
-	assert.Equal(s.T(), integration.Vendor, gjson.GetBytes(body, "userDevices.0.integrations.0.integrationVendor").String())
+
+	assert.Equal(s.T(), integration.Id, gjson.GetBytes(body, "userDevices.1.integrations.0.integrationId").String())
+	assert.Equal(s.T(), deviceID, gjson.GetBytes(body, "userDevices.1.integrations.0.externalId").String())
+	assert.Equal(s.T(), integration.Vendor, gjson.GetBytes(body, "userDevices.1.integrations.0.integrationVendor").String())
+	assert.Equal(s.T(), ud.ID, gjson.GetBytes(body, "userDevices.1.id").String())
+	assert.Equal(s.T(), "device2                    ", gjson.GetBytes(body, "userDevices.0.id").String())
 }
 
 func (s *UserDevicesControllerTestSuite) TestPatchVIN() {
@@ -439,6 +444,7 @@ func (s *UserDevicesControllerTestSuite) TestPatchVIN() {
 	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	s.deviceDefSvc.EXPECT().GetIntegrations(gomock.Any()).Return([]*grpc.Integration{integration}, nil)
 
+	s.usersClient.EXPECT().GetUser(gomock.Any(), &pb.GetUserRequest{Id: s.testUserID}).Return(&pb.User{Id: s.testUserID, EthereumAddress: nil}, nil)
 	evID := "4"
 	s.nhtsaService.EXPECT().DecodeVIN("5YJYGDEE5MF085533").Return(&services.NHTSADecodeVINResponse{
 		Results: []services.NHTSAResult{

--- a/internal/services/autopi/integration_test.go
+++ b/internal/services/autopi/integration_test.go
@@ -97,7 +97,7 @@ func (s *IntegrationTestSuite) Test_Pair_With_DD_HardwareTemplate_Success() {
 	md := []byte(`{"canProtocol":"06"}`)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, &md, "", s.pdb)
 	autoPIUnit := test.SetupCreateAutoPiUnitWithToken(s.T(), testUserID, unitID, autoPiTokenID, &ud.ID, s.pdb)
-	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, s.pdb)
+	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, null.Bytes{}, s.pdb)
 
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(deviceDefinitionID, "Ford", "F150", 2020, integration)
@@ -162,7 +162,7 @@ func (s *IntegrationTestSuite) Test_Pair_With_Make_HardwareTemplate_Success() {
 
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, "", s.pdb)
 	autoPIUnit := test.SetupCreateAutoPiUnitWithToken(s.T(), testUserID, unitID, autoPiTokenID, &ud.ID, s.pdb)
-	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, s.pdb)
+	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, null.Bytes{}, s.pdb)
 
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(deviceDefinitionID, "Ford", "F150", 2020, integration)
@@ -224,7 +224,7 @@ func (s *IntegrationTestSuite) Test_Pair_With_DD_DeviceStyle_HardwareTemplate_Su
 
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, "", s.pdb)
 	autoPIUnit := test.SetupCreateAutoPiUnitWithToken(s.T(), testUserID, unitID, autoPiTokenID, &ud.ID, s.pdb)
-	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, s.pdb)
+	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, null.Bytes{}, s.pdb)
 
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(deviceDefinitionID, "Ford", "F150", 2020, integration)
@@ -294,7 +294,7 @@ func (s *IntegrationTestSuite) Test_Pair_With_UserDeviceStyle_HardwareTemplate_S
 
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, deviceDefinitionID, nil, "", s.pdb)
 	autoPIUnit := test.SetupCreateAutoPiUnitWithToken(s.T(), testUserID, unitID, autoPiTokenID, &ud.ID, s.pdb)
-	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, s.pdb)
+	vehicleNFT := test.SetupCreateVehicleNFT(s.T(), ud.ID, vin, vehicleTokenID, null.Bytes{}, s.pdb)
 
 	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(deviceDefinitionID, "Ford", "F150", 2020, integration)

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -214,7 +214,7 @@ func SetupCreateUserDevice(t *testing.T, testUserID string, ddID string, metadat
 	return ud
 }
 
-func SetupCreateUserDeviceWithID(t *testing.T, testUserID string, deviceID string, ddID string, metadata *[]byte, vin string, pdb db.Store) models.UserDevice {
+func SetupCreateUserDeviceWithDeviceID(t *testing.T, testUserID string, deviceID string, ddID string, metadata *[]byte, vin string, pdb db.Store) models.UserDevice {
 	ud := models.UserDevice{
 		ID:                 deviceID,
 		UserID:             testUserID,


### PR DESCRIPTION
# Proposed Changes

- adjust `/user/devices/me` endpoint to include vehicles that are owned by the user's eth address, taking care to not double-show vehicles 