### PR TITLE
PLA-1411 Merge data based on timestamp

### DIFF
--- a/cmd/devices-api/main.go
+++ b/cmd/devices-api/main.go
@@ -112,6 +112,7 @@ func main() {
 		subcommands.Register(&syncDeviceTemplatesCmd{logger: logger, settings: settings, pdb: pdb}, "user devices")
 
 		subcommands.Register(&autopiClearVINCmd{logger: logger, settings: settings, pdb: pdb}, "autopi")
+		subcommands.Register(&fixSignalTimestamps{logger: logger, settings: settings, pdb: pdb}, "data-fixes")
 
 		flag.Parse()
 		os.Exit(int(subcommands.Execute(ctx)))

--- a/cmd/devices-api/temp_fix_signal_timestamps.go
+++ b/cmd/devices-api/temp_fix_signal_timestamps.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/DIMO-Network/devices-api/internal/config"
+	"github.com/DIMO-Network/devices-api/models"
+	"github.com/DIMO-Network/shared/db"
+	"github.com/google/subcommands"
+	"github.com/rs/zerolog"
+	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+)
+
+type fixSignalTimestamps struct {
+	logger   zerolog.Logger
+	settings config.Settings
+	pdb      db.Store
+}
+
+func (*fixSignalTimestamps) Name() string { return "fix-signal-timestamps" }
+func (*fixSignalTimestamps) Synopsis() string {
+	return "fixes the format of the timestamps in user_device_data signals"
+}
+func (*fixSignalTimestamps) Usage() string {
+	return `fix-signal-timestamps`
+}
+
+// nolint
+func (p *fixSignalTimestamps) SetFlags(f *flag.FlagSet) {
+
+}
+
+func (p *fixSignalTimestamps) Execute(ctx context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	all, err := models.UserDeviceData(models.UserDeviceDatumWhere.Signals.IsNotNull()).All(ctx, p.pdb.DBS().Reader)
+	if err != nil {
+		fmt.Println(err.Error())
+		return subcommands.ExitFailure
+	}
+	tx, err := p.pdb.DBS().Writer.BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+		ReadOnly:  false,
+	})
+	defer func(err error) {
+		if err != nil {
+			fmt.Println("Error:", err)
+			err2 := tx.Rollback()
+			if err2 != nil {
+				fmt.Println("Error:", err)
+				return
+			}
+		}
+	}(err)
+
+	if err != nil {
+		return subcommands.ExitFailure
+	}
+	for _, datum := range all {
+		var data map[string]interface{}
+		err := json.Unmarshal(datum.Signals.JSON, &data)
+		if err != nil {
+			return subcommands.ExitFailure
+		}
+
+		for _, value := range data {
+			if m, ok := value.(map[string]interface{}); ok {
+				if timestamp, ok := m["timestamp"].(string); ok {
+					lastCharTs := timestamp[len(timestamp)-1]
+					if string(lastCharTs) != "Z" {
+						m["timestamp"] = timestamp + "Z"
+					}
+				}
+			}
+		}
+
+		updatedJSON, err := json.Marshal(data)
+		if err != nil {
+			return subcommands.ExitFailure
+		}
+
+		datum.Signals = null.JSONFrom(updatedJSON)
+		_, err = datum.Update(ctx, tx, boil.Whitelist(models.UserDeviceDatumColumns.Signals, "updated_at"))
+		if err != nil {
+			return subcommands.ExitFailure
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		return subcommands.ExitFailure
+	}
+
+	return subcommands.ExitSuccess
+}

--- a/cmd/devices-api/temp_fix_signal_timestamps.go
+++ b/cmd/devices-api/temp_fix_signal_timestamps.go
@@ -58,22 +58,27 @@ func (p *fixSignalTimestamps) Execute(ctx context.Context, _ *flag.FlagSet, _ ..
 	if err != nil {
 		return subcommands.ExitFailure
 	}
+	fmt.Printf("found %d user_device_data to process\n", len(all))
 	for _, datum := range all {
 		var data map[string]interface{}
 		err := json.Unmarshal(datum.Signals.JSON, &data)
 		if err != nil {
 			return subcommands.ExitFailure
 		}
-
+		needsUpdate := false
 		for _, value := range data {
 			if m, ok := value.(map[string]interface{}); ok {
 				if timestamp, ok := m["timestamp"].(string); ok {
 					lastCharTs := timestamp[len(timestamp)-1]
 					if string(lastCharTs) != "Z" {
 						m["timestamp"] = timestamp + "Z"
+						needsUpdate = true
 					}
 				}
 			}
+		}
+		if !needsUpdate {
+			continue
 		}
 
 		updatedJSON, err := json.Marshal(data)
@@ -91,6 +96,6 @@ func (p *fixSignalTimestamps) Execute(ctx context.Context, _ *flag.FlagSet, _ ..
 	if err != nil {
 		return subcommands.ExitFailure
 	}
-
+	fmt.Println("successfully updated")
 	return subcommands.ExitSuccess
 }

--- a/cmd/devices-api/temp_fix_signal_timestamps.go
+++ b/cmd/devices-api/temp_fix_signal_timestamps.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+
 	"github.com/DIMO-Network/devices-api/internal/config"
 	"github.com/DIMO-Network/devices-api/models"
 	"github.com/DIMO-Network/shared/db"

--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -45,94 +45,101 @@ type GetUserDeviceErrorCodeQueriesResponseItem struct {
 
 func PrepareDeviceStatusInformation(ctx context.Context, ddSvc services.DeviceDefinitionService, deviceData models.UserDeviceDatumSlice, deviceDefinitionID string, deviceStyleID null.String, privilegeIDs []int64) DeviceSnapshot {
 	ds := DeviceSnapshot{}
-	// order the records by odometer asc so that if they both have it, the latter one replaces with more recent values.
-	sortByJSONOdometerAsc(deviceData)
+
+	// set the record dates to whatever most recent is
+	for _, datum := range deviceData {
+		if ds.RecordUpdatedAt == nil || ds.RecordUpdatedAt.Unix() < datum.UpdatedAt.Unix() {
+			ds.RecordCreatedAt = &datum.CreatedAt
+			ds.RecordUpdatedAt = &datum.UpdatedAt
+		}
+	}
+
+	// todo prefer odometer that is higher.
+	// future: prefer lat long from autopi
+	// future: if time btw UpdateAt and timestamp > 7 days, ignore property
+
+	// todo further refactor by passing in type for each option, then have switch in function below
+	if slices.Contains(privilegeIDs, NonLocationData) {
+		charging := findMostRecentSignal(deviceData, "charging", false)
+		if charging.Exists() {
+			c := charging.Get("value").Bool()
+			ds.Charging = &c
+		}
+		fuelPercentRemaining := findMostRecentSignal(deviceData, "fuelPercentRemaining", false)
+		if fuelPercentRemaining.Exists() {
+			f := fuelPercentRemaining.Get("value").Float()
+			if f >= 0.01 {
+				ds.FuelPercentRemaining = &f
+			}
+		}
+		batteryCapacity := findMostRecentSignal(deviceData, "batteryCapacity", false)
+		if batteryCapacity.Exists() {
+			b := batteryCapacity.Get("value").Int()
+			ds.BatteryCapacity = &b
+		}
+		oilLevel := findMostRecentSignal(deviceData, "oil", false)
+		if oilLevel.Exists() {
+			o := oilLevel.Get("value").Float()
+			ds.OilLevel = &o
+		}
+		stateOfCharge := findMostRecentSignal(deviceData, "soc", false)
+		if stateOfCharge.Exists() {
+			o := stateOfCharge.Get("value").Float()
+			ds.StateOfCharge = &o
+		}
+		chargeLimit := findMostRecentSignal(deviceData, "chargeLimit", false)
+		if chargeLimit.Exists() {
+			o := chargeLimit.Get("value").Float()
+			ds.ChargeLimit = &o
+		}
+		odometer := findMostRecentSignal(deviceData, "odometer", false)
+		if odometer.Exists() {
+			o := odometer.Get("value").Float()
+			ds.Odometer = &o
+		}
+		rangeG := findMostRecentSignal(deviceData, "range", false)
+		if rangeG.Exists() {
+			r := rangeG.Get("value").Float()
+			ds.Range = &r
+		}
+		batteryVoltage := findMostRecentSignal(deviceData, "batteryVoltage", false)
+		if batteryVoltage.Exists() {
+			bv := batteryVoltage.Get("value").Float()
+			ds.BatteryVoltage = &bv
+		}
+		ambientTemp := findMostRecentSignal(deviceData, "ambientTemp", false)
+		if ambientTemp.Exists() {
+			at := ambientTemp.Get("value").Float()
+			ds.AmbientTemp = &at
+		}
+		// TirePressure
+		tires := findMostRecentSignal(deviceData, "tires", false)
+		if tires.Exists() {
+			// weird thing here is in example payloads these are all ints, but the smartcar lib has as floats
+			ds.TirePressure = &smartcar.TirePressure{
+				FrontLeft:  tires.Get("value").Get("frontLeft").Float(),
+				FrontRight: tires.Get("value").Get("frontRight").Float(),
+				BackLeft:   tires.Get("value").Get("backLeft").Float(),
+				BackRight:  tires.Get("value").Get("backRight").Float(),
+			}
+		}
+	}
 
 	// merging data: foreach order by updatedAt desc, only set property if it exists in json data
 	for _, datum := range deviceData {
-		if datum.Data.Valid {
+		if datum.Signals.Valid {
 			// The response has the creation and update times of the most recently updated integration.
 			// For users with, e.g., both Smartcar and AutoPi this may produce confusing results.
-			ds.RecordCreatedAt = &datum.CreatedAt
-			ds.RecordUpdatedAt = &datum.UpdatedAt
 
-			// note we are assuming json property names are same accross smartcar, tesla, autopi, AND same types eg. int / float / string
-			// we could use reflection and just have single line assuming json name in struct matches what is in data
-			if slices.Contains(privilegeIDs, NonLocationData) {
-				charging := gjson.GetBytes(datum.Data.JSON, "charging")
-				if charging.Exists() {
-					c := charging.Bool()
-					ds.Charging = &c
-				}
-				fuelPercentRemaining := gjson.GetBytes(datum.Data.JSON, "fuelPercentRemaining")
-				if fuelPercentRemaining.Exists() {
-					f := fuelPercentRemaining.Float()
-					if f >= 0.01 {
-						ds.FuelPercentRemaining = &f
-					}
-				}
-				batteryCapacity := gjson.GetBytes(datum.Data.JSON, "batteryCapacity")
-				if batteryCapacity.Exists() {
-					b := batteryCapacity.Int()
-					ds.BatteryCapacity = &b
-				}
-				oilLevel := gjson.GetBytes(datum.Data.JSON, "oil")
-				if oilLevel.Exists() {
-					o := oilLevel.Float()
-					ds.OilLevel = &o
-				}
-				stateOfCharge := gjson.GetBytes(datum.Data.JSON, "soc")
-				if stateOfCharge.Exists() {
-					o := stateOfCharge.Float()
-					ds.StateOfCharge = &o
-				}
-				chargeLimit := gjson.GetBytes(datum.Data.JSON, "chargeLimit")
-				if chargeLimit.Exists() {
-					o := chargeLimit.Float()
-					ds.ChargeLimit = &o
-				}
-				odometer := gjson.GetBytes(datum.Data.JSON, "odometer")
-				if odometer.Exists() {
-					o := odometer.Float()
-					ds.Odometer = &o
-				}
-				rangeG := gjson.GetBytes(datum.Data.JSON, "range")
-				if rangeG.Exists() {
-					r := rangeG.Float()
-					ds.Range = &r
-				}
-				batteryVoltage := gjson.GetBytes(datum.Data.JSON, "batteryVoltage")
-				if batteryVoltage.Exists() {
-					bv := batteryVoltage.Float()
-					ds.BatteryVoltage = &bv
-				}
-				ambientTemp := gjson.GetBytes(datum.Data.JSON, "ambientTemp")
-				if ambientTemp.Exists() {
-					at := ambientTemp.Float()
-					ds.AmbientTemp = &at
-				}
-				// TirePressure
-				tires := gjson.GetBytes(datum.Data.JSON, "tires")
-				if tires.Exists() {
-					// weird thing here is in example payloads these are all ints, but the smartcar lib has as floats
-					ds.TirePressure = &smartcar.TirePressure{
-						FrontLeft:  tires.Get("frontLeft").Float(),
-						FrontRight: tires.Get("frontRight").Float(),
-						BackLeft:   tires.Get("backLeft").Float(),
-						BackRight:  tires.Get("backRight").Float(),
-					}
-				}
-
-			}
 			if slices.Contains(privilegeIDs, CurrentLocation) || slices.Contains(privilegeIDs, AllTimeLocation) {
-				latitude := gjson.GetBytes(datum.Data.JSON, "latitude")
+				latitude := findMostRecentSignal(deviceData, "latitude", false)
 				if latitude.Exists() {
-					l := latitude.Float()
+					l := latitude.Get("value").Float()
 					ds.Latitude = &l
 				}
-				longitude := gjson.GetBytes(datum.Data.JSON, "longitude")
+				longitude := findMostRecentSignal(deviceData, "longitude", false)
 				if longitude.Exists() {
-					l := longitude.Float()
+					l := longitude.Get("value").Float()
 					ds.Longitude = &l
 				}
 			}
@@ -148,6 +155,19 @@ func PrepareDeviceStatusInformation(ctx context.Context, ddSvc services.DeviceDe
 	}
 
 	return ds
+}
+
+// findMostRecentSignal finds the highest value float instead of most recent, eg. for odometer
+func findMostRecentSignal(udd models.UserDeviceDatumSlice, path string, highestFloat bool) gjson.Result {
+	// todo test
+	if len(udd) == 0 {
+		return gjson.Result{}
+	}
+	if len(udd) > 1 {
+		// todo if highestFloat, sort by value inside of path object
+		sortBySignalTimestampAsc(udd, path)
+	}
+	return gjson.GetBytes(udd[0].Signals.JSON, path)
 }
 
 // calculateRange returns the current estimated range based on fuel tank capacity, mpg, and fuelPercentRemaining and returns it in Kilometers
@@ -335,7 +355,7 @@ func (udc *UserDevicesController) QueryDeviceErrorCodes(c *fiber.Ctx) error {
 	})
 }
 
-// GetUserDevicesErrorCodeQueries godoc
+// GetUserDeviceErrorCodeQueries godoc
 // @Description Returns all error codes queries for user devices
 // @Tags        user-devices
 // @Success     200 {object} controllers.GetUserDeviceErrorCodeQueriesResponse
@@ -382,7 +402,7 @@ type DeviceSnapshot struct {
 	Latitude             *float64               `json:"latitude,omitempty"`
 	Longitude            *float64               `json:"longitude,omitempty"`
 	Range                *float64               `json:"range,omitempty"`
-	StateOfCharge        *float64               `json:"soc,omitempty"` // todo: change json to match after update frontend
+	StateOfCharge        *float64               `json:"soc,omitempty"`
 	ChargeLimit          *float64               `json:"chargeLimit,omitempty"`
 	RecordUpdatedAt      *time.Time             `json:"recordUpdatedAt,omitempty"`
 	RecordCreatedAt      *time.Time             `json:"recordCreatedAt,omitempty"`
@@ -403,5 +423,19 @@ func sortByJSONOdometerAsc(udd models.UserDeviceDatumSlice) {
 			return false
 		}
 		return fprj.Float() > fpri.Float()
+	})
+}
+
+func sortBySignalTimestampAsc(udd models.UserDeviceDatumSlice, path string) {
+	sort.Slice(udd, func(i, j int) bool {
+		fpri := gjson.GetBytes(udd[i].Signals.JSON, path+".timestamp")
+		fprj := gjson.GetBytes(udd[j].Signals.JSON, path+".timestamp")
+		// if one has it and the other does not, makes no difference
+		if fpri.Exists() && !fprj.Exists() {
+			return true
+		} else if !fpri.Exists() && fprj.Exists() {
+			return false
+		}
+		return fprj.Time().Unix() > fpri.Time().Unix()
 	})
 }

--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -53,9 +53,6 @@ func PrepareDeviceStatusInformation(ctx context.Context, ddSvc services.DeviceDe
 			ds.RecordUpdatedAt = &datum.UpdatedAt
 		}
 	}
-
-	// todo prefer odometer that is higher.
-	// future: prefer lat long from autopi
 	// future: if time btw UpdateAt and timestamp > 7 days, ignore property
 
 	// todo further refactor by passing in type for each option, then have switch in function below
@@ -417,8 +414,8 @@ type DeviceSnapshot struct {
 // sortBySignalValueDesc Sort user device data so the highest value is first
 func sortBySignalValueDesc(udd models.UserDeviceDatumSlice, path string) {
 	sort.Slice(udd, func(i, j int) bool {
-		fpri := gjson.GetBytes(udd[i].Data.JSON, path+"value")
-		fprj := gjson.GetBytes(udd[j].Data.JSON, path+"value")
+		fpri := gjson.GetBytes(udd[i].Signals.JSON, path+".value")
+		fprj := gjson.GetBytes(udd[j].Signals.JSON, path+".value")
 		// if one has it and the other does not, makes no difference
 		if fpri.Exists() && !fprj.Exists() {
 			return true

--- a/internal/controllers/device_data_controller_test.go
+++ b/internal/controllers/device_data_controller_test.go
@@ -81,8 +81,15 @@ func TestUserDevicesController_GetUserDeviceStatus(t *testing.T) {
 		_ = test.SetupCreateUserDeviceAPIIntegration(t, unitID, deviceID, ud.ID, smartCarInt.Id, pdb)
 		// SC data setup to  older
 		smartCarData := models.UserDeviceDatum{
-			UserDeviceID:        ud.ID,
-			Data:                null.JSONFrom([]byte(`{"oil": 0.6859999895095825, "range": 187.79, "tires": {"backLeft": 244, "backRight": 280, "frontLeft": 244, "frontRight": 252}, "charging": false, "latitude": 33.675048828125, "odometer": 195677.59375, "longitude": -117.85894775390625, "timestamp": "2022-05-18T16:49:37.879182265Z", "vehicleId": "0ef49636-28be-4f0f-8b08-4121137f0d5d", "fuelPercentRemaining": 0.4}`)),
+			UserDeviceID: ud.ID,
+			Signals: null.JSONFrom([]byte(`{"oil": {"value": 0.6859999895095825, "timestamp": "2023-04-27T14:57:37Z"}, 
+				"range": {"value": 187.79, "timestamp": "2023-04-27T14:57:37Z"}, 
+				"tires": {"value":{"backLeft": 244, "backRight": 280, "frontLeft": 244, "frontRight": 252}, "timestamp": "2023-04-27T14:57:37Z"}, 
+				"charging": {"value":false, "timestamp": "2023-04-27T14:57:37Z"}, 
+				"latitude": {"value":33.675048828125, "timestamp": "2023-04-27T14:57:37Z"}, 
+				"odometer": {"value":195677.59375, "timestamp": "2023-04-27T14:57:37Z"}, 
+				"longitude": {"value":-117.85894775390625, "timestamp": "2023-04-27T14:57:37Z"}
+				}`)),
 			CreatedAt:           time.Now().Add(time.Minute * -5),
 			UpdatedAt:           time.Now().Add(time.Minute * -5),
 			LastOdometerEventAt: null.TimeFrom(time.Now().Add(time.Minute * -5)),
@@ -92,8 +99,9 @@ func TestUserDevicesController_GetUserDeviceStatus(t *testing.T) {
 		assert.NoError(t, err)
 		// newer autopi data, expect to replace lat/long
 		autoPiData := models.UserDeviceDatum{
-			UserDeviceID:  ud.ID,
-			Data:          null.JSONFrom([]byte(`{"latitude": 33.75, "longitude": -117.91}`)),
+			UserDeviceID: ud.ID,
+			Signals: null.JSONFrom([]byte(`{"latitude": { "value": 33.75, "timestamp": "2023-04-27T15:57:37Z" },
+				"longitude": { "value": -117.91, "timestamp": "2023-04-27T15:57:37Z" } }`)),
 			CreatedAt:     time.Now().Add(time.Minute * -1),
 			UpdatedAt:     time.Now().Add(time.Minute * -1),
 			IntegrationID: autoPiInteg.Id,
@@ -131,7 +139,7 @@ func Test_sortBySignalValueDesc(t *testing.T) {
 			UserDeviceID: "123",
 			Signals: null.JSONFrom([]byte(`{ "odometer": {
     "value": 88164.32,
-    "timestamp": "2023-04-27T15:57:37"
+    "timestamp": "2023-04-27T15:57:37Z"
   }}`)),
 			CreatedAt:     time.Now(),
 			UpdatedAt:     time.Now(),
@@ -141,7 +149,7 @@ func Test_sortBySignalValueDesc(t *testing.T) {
 			UserDeviceID: "123",
 			Signals: null.JSONFrom([]byte(`{ "odometer": {
     "value": 88174.32,
-    "timestamp": "2023-04-27T16:57:37"
+    "timestamp": "2023-04-27T16:57:37Z"
   }}`)),
 			CreatedAt:     time.Now(),
 			UpdatedAt:     time.Now(),

--- a/internal/controllers/device_data_controller_test.go
+++ b/internal/controllers/device_data_controller_test.go
@@ -125,30 +125,69 @@ func TestUserDevicesController_GetUserDeviceStatus(t *testing.T) {
 	})
 }
 
-func Test_sortByJSONOdometerAsc(t *testing.T) {
+func Test_sortBySignalValueDesc(t *testing.T) {
 	udd := models.UserDeviceDatumSlice{
 		&models.UserDeviceDatum{
-			UserDeviceID:  "123",
-			Data:          null.JSONFrom([]byte(`{ "odometer": 100 }`)),
+			UserDeviceID: "123",
+			Signals: null.JSONFrom([]byte(`{ "odometer": {
+    "value": 88164.32,
+    "timestamp": "2023-04-27T15:57:37"
+  }}`)),
 			CreatedAt:     time.Now(),
 			UpdatedAt:     time.Now(),
 			IntegrationID: "123",
 		},
 		&models.UserDeviceDatum{
-			UserDeviceID:  "123",
-			Data:          null.JSONFrom([]byte(`{ "odometer": 90}`)),
+			UserDeviceID: "123",
+			Signals: null.JSONFrom([]byte(`{ "odometer": {
+    "value": 88174.32,
+    "timestamp": "2023-04-27T16:57:37"
+  }}`)),
 			CreatedAt:     time.Now(),
 			UpdatedAt:     time.Now(),
 			IntegrationID: "345",
 		},
 	}
 	// validate setup is ok
-	assert.Equal(t, float64(100), gjson.GetBytes(udd[0].Data.JSON, "odometer").Float())
-	assert.Equal(t, float64(90), gjson.GetBytes(udd[1].Data.JSON, "odometer").Float())
+	assert.Equal(t, 88164.32, gjson.GetBytes(udd[0].Signals.JSON, "odometer.value").Float())
+	assert.Equal(t, 88174.32, gjson.GetBytes(udd[1].Signals.JSON, "odometer.value").Float())
 	// sort and validate
-	sortByJSONOdometerAsc(udd)
-	assert.Equal(t, float64(90), gjson.GetBytes(udd[0].Data.JSON, "odometer").Float())
-	assert.Equal(t, float64(100), gjson.GetBytes(udd[1].Data.JSON, "odometer").Float())
+	sortBySignalValueDesc(udd, "odometer")
+	assert.Equal(t, 88174.32, gjson.GetBytes(udd[0].Signals.JSON, "odometer.value").Float())
+	assert.Equal(t, 88164.32, gjson.GetBytes(udd[1].Signals.JSON, "odometer.value").Float())
+}
+
+func Test_sortBySignalTimestampDesc(t *testing.T) {
+	udd := models.UserDeviceDatumSlice{
+		&models.UserDeviceDatum{
+			UserDeviceID: "123",
+			Signals: null.JSONFrom([]byte(`{ "odometer": {
+    "value": 88164.32,
+    "timestamp": "2023-04-27T15:57:37Z"
+  }}`)),
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+			IntegrationID: "123",
+		},
+		&models.UserDeviceDatum{
+			UserDeviceID: "123",
+			Signals: null.JSONFrom([]byte(`{ "odometer": {
+    "value": 88174.32,
+    "timestamp": "2023-04-27T16:57:37Z"
+  }}`)),
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+			IntegrationID: "345",
+		},
+	}
+	// validate setup is ok
+	assert.Equal(t, 88164.32, gjson.GetBytes(udd[0].Signals.JSON, "odometer.value").Float())
+	assert.Equal(t, 88174.32, gjson.GetBytes(udd[1].Signals.JSON, "odometer.value").Float())
+	// sort and validate
+	sortBySignalTimestampDesc(udd, "odometer")
+	assert.Equal(t, 88174.32, gjson.GetBytes(udd[0].Signals.JSON, "odometer.value").Float())
+	assert.Equal(t, "2023-04-27T16:57:37Z", gjson.GetBytes(udd[0].Signals.JSON, "odometer.timestamp").Time().Format(time.RFC3339))
+	assert.Equal(t, 88164.32, gjson.GetBytes(udd[1].Signals.JSON, "odometer.value").Float())
 }
 
 func TestUserDevicesController_calculateRange(t *testing.T) {

--- a/internal/controllers/nft_controller.go
+++ b/internal/controllers/nft_controller.go
@@ -414,9 +414,9 @@ func (nc *NFTController) GetVehicleStatus(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusNotFound, "NFT not found.")
 	}
 
-	deviceData, err := models.UserDeviceData(models.UserDeviceDatumWhere.UserDeviceID.EQ(nft.R.UserDevice.ID),
-		qm.OrderBy("updated_at asc")).All(c.Context(), nc.DBS().Reader)
-	if errors.Is(err, sql.ErrNoRows) || len(deviceData) == 0 || !deviceData[0].Data.Valid {
+	deviceData, err := models.UserDeviceData(models.UserDeviceDatumWhere.UserDeviceID.EQ(nft.R.UserDevice.ID)).
+		All(c.Context(), nc.DBS().Reader)
+	if errors.Is(err, sql.ErrNoRows) || len(deviceData) == 0 || !deviceData[0].Signals.Valid {
 		return fiber.NewError(fiber.StatusNotFound, "no status updates yet")
 	}
 	if err != nil {

--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	smartcar "github.com/smartcar/go-sdk"
 	"math/big"
 	"reflect"
 	"regexp"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	smartcar "github.com/smartcar/go-sdk"
 
 	"github.com/DIMO-Network/shared/redis"
 

--- a/internal/services/device_status_ingest_service.go
+++ b/internal/services/device_status_ingest_service.go
@@ -312,7 +312,7 @@ func mergeSignals(currentData map[string]interface{}, newData map[string]interfa
 	// now iterate over new data and update any keys present in the new data with the events timestamp
 	for k, v := range newData {
 		merged[k] = map[string]interface{}{
-			"timestamp": t.Format("2006-01-02T15:04:05"),
+			"timestamp": t.Format("2006-01-02T15:04:05Z"), // utc tz RFC3339
 			"value":     v,
 		}
 	}

--- a/internal/services/device_status_ingest_service_test.go
+++ b/internal/services/device_status_ingest_service_test.go
@@ -322,10 +322,10 @@ func TestAutoPiStatusWithSignals(t *testing.T) {
 	assert.Equal("xx", gjson.GetBytes(dat1.Signals.JSON, "signal_name_version_1.timestamp").Str, "signal 1 ts should not change and be present")
 	assert.Equal(23.4, gjson.GetBytes(dat1.Signals.JSON, "signal_name_version_1.value").Num, "signal 1 value should not change and be present")
 	// assume UTC tz
-	assert.Equal(input.Time.Format("2006-01-02T15:04:05"), gjson.GetBytes(dat1.Signals.JSON, "odometer.timestamp").Str, "odometer ts should be updated from latest event")
+	assert.Equal(input.Time.Format("2006-01-02T15:04:05Z"), gjson.GetBytes(dat1.Signals.JSON, "odometer.timestamp").Str, "odometer ts should be updated from latest event")
 	assert.Equal(45.22, gjson.GetBytes(dat1.Signals.JSON, "odometer.value").Num, "odometer value should be updated from latest event")
 
-	assert.Equal(input.Time.Format("2006-01-02T15:04:05"), gjson.GetBytes(dat1.Signals.JSON, "signal_name_version_2.timestamp").Str, "signal 2 ts should be updated from latest event")
+	assert.Equal(input.Time.Format("2006-01-02T15:04:05Z"), gjson.GetBytes(dat1.Signals.JSON, "signal_name_version_2.timestamp").Str, "signal 2 ts should be updated from latest event")
 	assert.Equal(12.3, gjson.GetBytes(dat1.Signals.JSON, "signal_name_version_2.value").Num, "signal 2 value should be updated from latest event")
 }
 


### PR DESCRIPTION
# Proposed Changes
- leverage the new signals column to better merge data so that we pick the most recent at a signal level
- with odometer specifically, always take the bigger number
- fix ingest when writing timestamp to set utc 0 (add Z char)
- add a script to fix the timestamps on existing data

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->
`.../status`

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->
- run the data fix as soon as this deploys