### PR TITLE
PLA-1425 Avoid bug when signals was null from stale data and filter for > 2 weeks

### DIFF
--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -220,12 +220,14 @@ func (udc *UserDevicesController) GetUserDeviceStatus(c *fiber.Ctx) error {
 
 	deviceData, err := models.UserDeviceData(
 		models.UserDeviceDatumWhere.UserDeviceID.EQ(userDevice.ID),
+		models.UserDeviceDatumWhere.Signals.IsNotNull(),
+		models.UserDeviceDatumWhere.UpdatedAt.GT(time.Now().Add(-14*24*time.Hour)),
 	).All(c.Context(), udc.DBS().Reader)
 	if err != nil {
 		return err
 	}
 
-	if len(deviceData) == 0 || !deviceData[0].Signals.Valid {
+	if len(deviceData) == 0 {
 		return fiber.NewError(fiber.StatusNotFound, "No status updates yet.")
 	}
 


### PR DESCRIPTION
# Proposed Changes
if people had multiple integrations, with one of them being very stale data, this would cause nothing to return b/c the didn't have anything in the signals column. Instead we do a query level filter for must all return with signals and be newer than 2 weeks as well. 

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->