### PR TITLE
Save Smartcar external id and available endpoints

### DIFF
--- a/charts/devices-api/values-prod.yaml
+++ b/charts/devices-api/values-prod.yaml
@@ -41,6 +41,7 @@ env:
   AFTERMARKET_DEVICE_CONTRACT_ADDRESS: '0x9c94c395cbcbde662235e0a9d3bb87ad708561ba'
   DIMO_CONTRACT_APIURL: https://contracts-api.dimo.zone/
   NATS_URL: nats-prod:4222
+  SYNTHETIC_DEVICES_ENABLED: false
 ingress:
   enabled: true
   className: nginx

--- a/charts/devices-api/values.yaml
+++ b/charts/devices-api/values.yaml
@@ -83,6 +83,7 @@ env:
   NATS_VALUATION_SUBJECT: dd_valuation_tasks
   NATS_DURABLE_CONSUMER: dd-valuation-task-consumer
   NATS_ACK_TIMEOUT: 2m
+  SYNTHETIC_DEVICES_ENABLED: true
 service:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Little notes

* Error handling could be better
* Used the assertion methods directly on the suite, that's kinda neat
* Was more specific in checking arguments to the mocks