### PR TITLE
PRO-1326 update route naming to use aftermarket device and serial

### DIFF
--- a/cmd/devices-api/api.go
+++ b/cmd/devices-api/api.go
@@ -211,18 +211,27 @@ func startWebAPI(logger zerolog.Logger, settings *config.Settings, pdb db.Store,
 	v1Auth.Get("/integrations", userDeviceController.GetIntegrations)
 
 	// Autopi specific routes.
-	apOwnerMw := owner.AutoPi(pdb, usersClient, &logger)
-	apOwner := v1Auth.Group("/autopi/unit/:unitID", apOwnerMw)
+	amdOwnerMw := owner.AftermarketDevice(pdb, usersClient, &logger)
+	apOwner := v1Auth.Group("/autopi/unit/:serial", amdOwnerMw)
+	// same as above but AftermarketDevice
+	amdOwner := v1Auth.Group("/aftermarket/device/hw/:serial", amdOwnerMw)
 
 	apOwner.Get("/", userDeviceController.GetAutoPiUnitInfo)
-	apOwner.Post("/update", userDeviceController.StartAutoPiUpdateTask)
+	amdOwner.Get("/", userDeviceController.GetAutoPiUnitInfo)
 
-	// AutoPi claiming
+	apOwner.Post("/update", userDeviceController.StartAutoPiUpdateTask)
+	amdOwner.Post("/update", userDeviceController.StartAutoPiUpdateTask)
+
+	// AftermarketDevice claiming, formerly AutoPi
 	apOwner.Get("/commands/claim", userDeviceController.GetAutoPiClaimMessage)
+	amdOwner.Get("/commands/claim", userDeviceController.GetAutoPiClaimMessage)
+
 	apOwner.Post("/commands/claim", userDeviceController.PostClaimAutoPi).Name("PostClaimAutoPi")
+	amdOwner.Post("/commands/claim", userDeviceController.PostClaimAutoPi).Name("PostClaimAutoPi")
 	if !settings.IsProduction() {
 		// Used by mobile to test. Easy to misuse.
 		apOwner.Post("/commands/unclaim", userDeviceController.PostUnclaimAutoPi)
+		amdOwner.Post("/commands/unclaim", userDeviceController.PostUnclaimAutoPi)
 	}
 
 	// geofence
@@ -295,13 +304,18 @@ func startWebAPI(logger zerolog.Logger, settings *config.Settings, pdb db.Store,
 
 	udOwner.Post("/commands/opt-in", userDeviceController.DeviceOptIn)
 
-	// AutoPi pairing and unpairing.
+	// AftermarketDevice pairing and unpairing.
 	udOwner.Get("/autopi/commands/pair", userDeviceController.GetAutoPiPairMessage)
+	udOwner.Get("/aftermarket/commands/pair", userDeviceController.GetAutoPiPairMessage)
 	udOwner.Post("/autopi/commands/pair", userDeviceController.PostPairAutoPi)
+	udOwner.Post("/aftermarket/commands/pair", userDeviceController.PostPairAutoPi)
 	udOwner.Get("/autopi/commands/unpair", userDeviceController.GetAutoPiUnpairMessage)
+	udOwner.Get("/aftermarket/commands/unpair", userDeviceController.GetAutoPiUnpairMessage)
 	udOwner.Post("/autopi/commands/unpair", userDeviceController.UnpairAutoPi)
+	udOwner.Post("/aftermarket/commands/unpair", userDeviceController.UnpairAutoPi)
 
 	udOwner.Post("/autopi/commands/cloud-repair", userDeviceController.CloudRepairAutoPi)
+	udOwner.Post("/aftermarket/commands/cloud-repair", userDeviceController.CloudRepairAutoPi)
 
 	go startValuationConsumer(settings, pdb.DBS, &logger, ddSvc, natsSvc)
 

--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -433,17 +433,17 @@ func (udc *UserDevicesController) OpenFrunk(c *fiber.Ctx) error {
 }
 
 // GetAutoPiUnitInfo godoc
-// @Description gets the information about the autopi by the unitId
+// @Description gets the information about the aftermarket device by the hw serial
 // @Tags        integrations
 // @Produce     json
-// @Param       unitID path     string true "autopi unit id"
+// @Param       serial path     string true "autopi unit id or macaron serial"
 // @Success     200    {object} controllers.AutoPiDeviceInfo
 // @Security    BearerAuth
-// @Router      /autopi/unit/:unitID [get]
+// @Router      /aftermarket/device/hw/:serial [get]
 func (udc *UserDevicesController) GetAutoPiUnitInfo(c *fiber.Ctx) error {
 	const minimumAutoPiRelease = "v1.22.8" // correct semver has leading v
 
-	unitID := c.Locals("unitID").(string)
+	unitID := c.Locals("serial").(string)
 
 	// This is hitting AutoPi.
 	unit, err := udc.autoPiSvc.GetDeviceByUnitID(unitID)
@@ -561,15 +561,15 @@ func (udc *UserDevicesController) GetAutoPiUnitInfo(c *fiber.Ctx) error {
 }
 
 // StartAutoPiUpdateTask godoc
-// @Description checks to see if autopi unit needs to be updated, and starts update process if so.
+// @Description checks to see if aftermarket device needs to be updated, and starts update process if so.
 // @Tags        integrations
 // @Produce     json
-// @Param       unitID path     string true "autopi unit id", ie. physical barcode
+// @Param       serial path     string true "autopi unit id", ie. physical barcode
 // @Success     200    {object} services.AutoPiTask
 // @Security    BearerAuth
-// @Router      /autopi/unit/:unitID/update [post]
+// @Router      /aftermarket/device/hw/:serial/update [post]
 func (udc *UserDevicesController) StartAutoPiUpdateTask(c *fiber.Ctx) error {
-	unitID := c.Locals("unitID").(string)
+	unitID := c.Locals("serial").(string)
 	userID := helpers.GetUserID(c)
 
 	// check if device already updated
@@ -605,18 +605,18 @@ func (udc *UserDevicesController) StartAutoPiUpdateTask(c *fiber.Ctx) error {
 }
 
 // GetAutoPiClaimMessage godoc
-// @Description Return the EIP-712 payload to be signed for AutoPi device claiming.
+// @Description Return the EIP-712 payload to be signed for Aftermarket device claiming.
 // @Produce json
-// @Param unitID path string true "AutoPi unit id"
+// @Param serial path string true "AutoPi unit id"
 // @Success 200 {object} signer.TypedData
 // @Security BearerAuth
-// @Router /autopi/unit/:unitID/commands/claim [get]
+// @Router /aftermarket/device/hw/:serial/commands/claim [get]
 func (udc *UserDevicesController) GetAutoPiClaimMessage(c *fiber.Ctx) error {
 	userID := helpers.GetUserID(c)
 
-	unitID := c.Params("unitID")
+	unitID := c.Params("serial")
 
-	logger := udc.log.With().Str("userId", userID).Str("unitId", unitID).Logger()
+	logger := udc.log.With().Str("userId", userID).Str("serial", unitID).Logger()
 	logger.Info().Msg("Got AutoPi claim request.")
 
 	unit, err := models.AftermarketDevices(
@@ -680,7 +680,7 @@ func (udc *UserDevicesController) GetAutoPiClaimMessage(c *fiber.Ctx) error {
 }
 
 // GetAutoPiPairMessage godoc
-// @Description Return the EIP-712 payload to be signed for AutoPi device pairing. The device must
+// @Description Return the EIP-712 payload to be signed for Aftermarket device pairing. The device must
 // @Description either already be integrated with the vehicle, or you must provide its unit id
 // @Description as a query parameter. In the latter case, the integration process will start
 // @Description once the transaction confirms.
@@ -689,7 +689,7 @@ func (udc *UserDevicesController) GetAutoPiClaimMessage(c *fiber.Ctx) error {
 // @Param external_id query string false "External id, for now AutoPi unit id"
 // @Success 200 {object} signer.TypedData "EIP-712 message for pairing."
 // @Security BearerAuth
-// @Router /user/devices/:userDeviceID/autopi/commands/pair [get]
+// @Router /user/devices/:userDeviceID/aftermarket/commands/pair [get]
 func (udc *UserDevicesController) GetAutoPiPairMessage(c *fiber.Ctx) error {
 	userID := helpers.GetUserID(c)
 
@@ -818,12 +818,12 @@ func (udc *UserDevicesController) GetAutoPiPairMessage(c *fiber.Ctx) error {
 }
 
 // PostPairAutoPi godoc
-// @Description Submit the signature for pairing this device with its attached AutoPi.
+// @Description Submit the signature for pairing this device with its attached Aftermarket.
 // @Produce json
 // @Param userDeviceID path string true "Device id"
 // @Param userSignature body controllers.AutoPiPairRequest true "User signature."
 // @Security BearerAuth
-// @Router /user/devices/:userDeviceID/autopi/commands/pair [post]
+// @Router /user/devices/:userDeviceID/aftermarket/commands/pair [post]
 func (udc *UserDevicesController) PostPairAutoPi(c *fiber.Ctx) error {
 	userID := helpers.GetUserID(c)
 
@@ -1048,12 +1048,12 @@ func (udc *UserDevicesController) PostPairAutoPi(c *fiber.Ctx) error {
 // @Param userDeviceID path string true "Device id"
 // @Success 204
 // @Security BearerAuth
-// @Router /user/devices/:userDeviceID/autopi/commands/cloud-repair [post]
+// @Router /user/devices/:userDeviceID/aftermarket/commands/cloud-repair [post]
 func (udc *UserDevicesController) CloudRepairAutoPi(c *fiber.Ctx) error {
 	userDeviceID := c.Params("userDeviceID")
 
 	logger := helpers.GetLogger(c, udc.log)
-	logger.Info().Msg("Got AutoPi pair request.")
+	logger.Info().Msg("Got Aftermarket pair request.")
 
 	ud, err := models.UserDevices(
 		models.UserDeviceWhere.ID.EQ(userDeviceID),
@@ -1087,12 +1087,12 @@ func (udc *UserDevicesController) CloudRepairAutoPi(c *fiber.Ctx) error {
 }
 
 // UnpairAutoPi godoc
-// @Description Submit the signature for unpairing this device from its attached AutoPi.
+// @Description Submit the signature for unpairing this device from its attached Aftermarket.
 // @Produce json
 // @Param userDeviceID path string true "Device id"
 // @Param userSignature body controllers.AutoPiPairRequest true "User signature."
 // @Security BearerAuth
-// @Router /user/devices/:userDeviceID/autopi/commands/unpair [post]
+// @Router /user/devices/:userDeviceID/aftermarket/commands/unpair [post]
 func (udc *UserDevicesController) UnpairAutoPi(c *fiber.Ctx) error {
 	userID := helpers.GetUserID(c)
 
@@ -1111,7 +1111,7 @@ func (udc *UserDevicesController) UnpairAutoPi(c *fiber.Ctx) error {
 	userDeviceID := c.Params("userDeviceID")
 
 	logger := helpers.GetLogger(c, udc.log)
-	logger.Info().Msg("Got AutoPi unpair request.")
+	logger.Info().Msg("Got Aftermarket unpair request.")
 
 	// TODO(elffjs): Is SELECT ... FOR UPDATE better here?
 	tx, err := udc.DBS().Writer.BeginTx(c.Context(), &sql.TxOptions{Isolation: sql.LevelSerializable})
@@ -1222,19 +1222,19 @@ func (udc *UserDevicesController) UnpairAutoPi(c *fiber.Ctx) error {
 }
 
 // GetAutoPiUnpairMessage godoc
-// @Description Return the EIP-712 payload to be signed for AutoPi device unpairing.
+// @Description Return the EIP-712 payload to be signed for Aftermarket device unpairing.
 // @Produce json
 // @Param userDeviceID path string true "Device id"
 // @Success 200 {object} signer.TypedData
 // @Security BearerAuth
-// @Router /user/devices/:userDeviceID/autopi/commands/unpair [get]
+// @Router /user/devices/:userDeviceID/aftermarket/commands/unpair [get]
 func (udc *UserDevicesController) GetAutoPiUnpairMessage(c *fiber.Ctx) error {
 	userID := helpers.GetUserID(c)
 
 	userDeviceID := c.Params("userDeviceID")
 
 	logger := helpers.GetLogger(c, udc.log)
-	logger.Info().Msg("Got AutoPi pair request.")
+	logger.Info().Msg("Got Aftermarket pair request.")
 
 	autoPiInt, err := udc.DeviceDefIntSvc.GetAutoPiIntegration(c.Context())
 	if err != nil {
@@ -1337,15 +1337,15 @@ type AutoPiPairRequest struct {
 // @Description Dev-only endpoint for removing a claim. Removes the flag on-chain and clears
 // @Description the owner in the database.
 // @Produce json
-// @Param unitID path string true "AutoPi unit id"
+// @Param serial path string true "AutoPi unit id"
 // @Success 204
 // @Security BearerAuth
-// @Router /autopi/unit/:unitID/commands/unclaim [post]
+// @Router /aftermarket/device/hw/:serial/commands/unclaim [post]
 func (udc *UserDevicesController) PostUnclaimAutoPi(c *fiber.Ctx) error {
 	userID := helpers.GetUserID(c)
-	unitID := c.Params("unitID")
+	unitID := c.Params("serial")
 
-	logger := udc.log.With().Str("userId", userID).Str("autoPiUnitId", unitID).Str("route", c.Route().Name).Logger()
+	logger := udc.log.With().Str("userId", userID).Str("serial", unitID).Str("route", c.Route().Name).Logger()
 
 	logger.Info().Msg("Got unclaim request.")
 
@@ -1388,18 +1388,18 @@ func (udc *UserDevicesController) PostUnclaimAutoPi(c *fiber.Ctx) error {
 }
 
 // PostClaimAutoPi godoc
-// @Description Return the EIP-712 payload to be signed for AutoPi device claiming.
+// @Description Return the EIP-712 payload to be signed for Aftermarket device claiming.
 // @Produce json
-// @Param unitID path string true "AutoPi unit id"
+// @Param serial path string true "AutoPi unit id"
 // @Param claimRequest body controllers.AutoPiClaimRequest true "Signatures from the user and AutoPi"
 // @Success 204
 // @Security BearerAuth
-// @Router /autopi/unit/:unitID/commands/claim [post]
+// @Router /aftermarket/device/hw/:serial/commands/claim [post]
 func (udc *UserDevicesController) PostClaimAutoPi(c *fiber.Ctx) error {
 	userID := helpers.GetUserID(c)
-	unitID := c.Params("unitID")
+	unitID := c.Params("serial")
 
-	logger := udc.log.With().Str("userId", userID).Str("autoPiUnitId", unitID).Str("route", c.Route().Name).Logger()
+	logger := udc.log.With().Str("userId", userID).Str("serial", unitID).Str("route", c.Route().Name).Logger()
 
 	reqBody := AutoPiClaimRequest{}
 	err := c.BodyParser(&reqBody)

--- a/internal/controllers/user_integrations_controller_test.go
+++ b/internal/controllers/user_integrations_controller_test.go
@@ -591,7 +591,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetAutoPiInfoNoUDAI_ShouldUpda
 	c := NewUserDevicesController(&config.Settings{Port: "3000", Environment: environment}, s.pdb.DBS, test.Logger(), s.deviceDefSvc, s.deviceDefIntSvc, &fakeEventService{}, s.scClient, s.scTaskSvc, s.teslaSvc, s.teslaTaskService, new(shared.ROT13Cipher), autopiAPISvc, nil, s.autoPiIngest, s.deviceDefinitionRegistrar, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	app := fiber.New()
 	logger := zerolog.Nop()
-	app.Get("/autopi/unit/:unitID", test.AuthInjectorTestHandler(testUserID), owner.AutoPi(s.pdb, s.userClient, &logger), c.GetAutoPiUnitInfo)
+	app.Get("/autopi/unit/:unitID", test.AuthInjectorTestHandler(testUserID), owner.AftermarketDevice(s.pdb, s.userClient, &logger), c.GetAutoPiUnitInfo)
 	// arrange
 	const unitID = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
 	test.SetupCreateAftermarketDevice(s.T(), "", nil, unitID, nil, s.pdb)
@@ -629,7 +629,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetAutoPiInfoNoUDAI_UpToDate()
 	c := NewUserDevicesController(&config.Settings{Port: "3000", Environment: environment}, s.pdb.DBS, test.Logger(), s.deviceDefSvc, s.deviceDefIntSvc, &fakeEventService{}, s.scClient, s.scTaskSvc, s.teslaSvc, s.teslaTaskService, new(shared.ROT13Cipher), autopiAPISvc, nil, s.autoPiIngest, s.deviceDefinitionRegistrar, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	app := fiber.New()
 	logger := zerolog.Nop()
-	app.Get("/autopi/unit/:unitID", test.AuthInjectorTestHandler(testUserID), owner.AutoPi(s.pdb, s.userClient, &logger), c.GetAutoPiUnitInfo)
+	app.Get("/autopi/unit/:unitID", test.AuthInjectorTestHandler(testUserID), owner.AftermarketDevice(s.pdb, s.userClient, &logger), c.GetAutoPiUnitInfo)
 	// arrange
 	const unitID = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
 	test.SetupCreateAftermarketDevice(s.T(), "", nil, unitID, nil, s.pdb)
@@ -664,7 +664,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetAutoPiInfoNoUDAI_FutureUpda
 	c := NewUserDevicesController(&config.Settings{Port: "3000", Environment: environment}, s.pdb.DBS, test.Logger(), s.deviceDefSvc, s.deviceDefIntSvc, &fakeEventService{}, s.scClient, s.scTaskSvc, s.teslaSvc, s.teslaTaskService, new(shared.ROT13Cipher), autopiAPISvc, nil, s.autoPiIngest, s.deviceDefinitionRegistrar, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	app := fiber.New()
 	logger := zerolog.Nop()
-	app.Get("/autopi/unit/:unitID", test.AuthInjectorTestHandler(testUserID), owner.AutoPi(s.pdb, s.userClient, &logger), c.GetAutoPiUnitInfo)
+	app.Get("/autopi/unit/:unitID", test.AuthInjectorTestHandler(testUserID), owner.AftermarketDevice(s.pdb, s.userClient, &logger), c.GetAutoPiUnitInfo)
 	// arrange
 	const unitID = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
 	test.SetupCreateAftermarketDevice(s.T(), "", nil, unitID, nil, s.pdb)
@@ -700,7 +700,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetAutoPiInfoNoUDAI_ShouldUpda
 	c := NewUserDevicesController(&config.Settings{Port: "3000", Environment: environment}, s.pdb.DBS, test.Logger(), s.deviceDefSvc, s.deviceDefIntSvc, &fakeEventService{}, s.scClient, s.scTaskSvc, s.teslaSvc, s.teslaTaskService, new(shared.ROT13Cipher), autopiAPISvc, nil, s.autoPiIngest, s.deviceDefinitionRegistrar, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	app := fiber.New()
 	logger := zerolog.Nop()
-	app.Get("/autopi/unit/:unitID", test.AuthInjectorTestHandler(testUserID), owner.AutoPi(s.pdb, s.userClient, &logger), c.GetAutoPiUnitInfo)
+	app.Get("/autopi/unit/:unitID", test.AuthInjectorTestHandler(testUserID), owner.AftermarketDevice(s.pdb, s.userClient, &logger), c.GetAutoPiUnitInfo)
 	// arrange
 	const unitID = "431d2e89-46f1-6884-6226-5d1ad20c84d9"
 	test.SetupCreateAftermarketDevice(s.T(), "", nil, unitID, nil, s.pdb)

--- a/internal/middleware/owner/owner_test.go
+++ b/internal/middleware/owner/owner_test.go
@@ -152,7 +152,7 @@ func TestAutoPiOwnerMiddleware(t *testing.T) {
 	logger := test.Logger()
 
 	usersClient := &test.UsersClient{}
-	middleware := AutoPi(pdb, usersClient, logger)
+	middleware := AftermarketDevice(pdb, usersClient, logger)
 
 	app := test.SetupAppFiber(*logger)
 	app.Get("/:unitID", test.AuthInjectorTestHandler(userID), middleware, func(c *fiber.Ctx) error {
@@ -173,7 +173,7 @@ func TestAutoPiOwnerMiddleware(t *testing.T) {
 		ExpectedCode       int
 	}{
 		{
-			Name:         "AutoPi not minted, or unit ID invalid.",
+			Name:         "AftermarketDevice not minted, or unit ID invalid.",
 			ExpectedCode: 404,
 		},
 		{
@@ -194,7 +194,7 @@ func TestAutoPiOwnerMiddleware(t *testing.T) {
 			AutoPiUnitID:       unitID,
 		},
 		{
-			Name:               "user is not owner of paired vehicle or AutoPi",
+			Name:               "user is not owner of paired vehicle or AftermarketDevice",
 			ExpectedCode:       403,
 			AutoPiVehicleToken: types.NewNullDecimal(decimal.New(int64(1), 0)),
 			AutoPiUnitID:       unitID,


### PR DESCRIPTION
# Proposed Changes
- owner middleware use serial instead of unitID
- update paths and docs to use aftermarket device instead of autopi

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->