### PR TITLE
SI-2176-preload-jsonld-vc-issuer

### DIFF
--- a/internal/services/issuer/verifiable_credential_test.go
+++ b/internal/services/issuer/verifiable_credential_test.go
@@ -81,7 +81,6 @@ func TestCredentialTestSuite(t *testing.T) {
 }
 
 func (s *CredentialTestSuite) TestVerifiableCredential() {
-	s.T().Skip("Isolate this test from the network before putting it in CI.")
 	ctx := context.Background()
 	vin := "1G6AL1RY2K0111939"
 	tokenID := big.NewInt(3)

--- a/internal/services/issuer/w3c_2018_credentials_v1.json
+++ b/internal/services/issuer/w3c_2018_credentials_v1.json
@@ -1,0 +1,307 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+
+    "id": "@id",
+    "type": "@type",
+
+    "VerifiableCredential": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "credentialSchema": {
+          "@id": "cred:credentialSchema",
+          "@type": "@id",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "cred": "https://www.w3.org/2018/credentials#",
+
+            "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018"
+          }
+        },
+        "credentialStatus": { "@id": "cred:credentialStatus", "@type": "@id" },
+        "credentialSubject": {
+          "@id": "cred:credentialSubject",
+          "@type": "@id"
+        },
+        "evidence": { "@id": "cred:evidence", "@type": "@id" },
+        "expirationDate": {
+          "@id": "cred:expirationDate",
+          "@type": "xsd:dateTime"
+        },
+        "holder": { "@id": "cred:holder", "@type": "@id" },
+        "issued": { "@id": "cred:issued", "@type": "xsd:dateTime" },
+        "issuer": { "@id": "cred:issuer", "@type": "@id" },
+        "issuanceDate": { "@id": "cred:issuanceDate", "@type": "xsd:dateTime" },
+        "proof": { "@id": "sec:proof", "@type": "@id", "@container": "@graph" },
+        "refreshService": {
+          "@id": "cred:refreshService",
+          "@type": "@id",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "cred": "https://www.w3.org/2018/credentials#",
+
+            "ManualRefreshService2018": "cred:ManualRefreshService2018"
+          }
+        },
+        "termsOfUse": { "@id": "cred:termsOfUse", "@type": "@id" },
+        "validFrom": { "@id": "cred:validFrom", "@type": "xsd:dateTime" },
+        "validUntil": { "@id": "cred:validUntil", "@type": "xsd:dateTime" }
+      }
+    },
+
+    "VerifiablePresentation": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiablePresentation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
+
+        "holder": { "@id": "cred:holder", "@type": "@id" },
+        "proof": { "@id": "sec:proof", "@type": "@id", "@container": "@graph" },
+        "verifiableCredential": {
+          "@id": "cred:verifiableCredential",
+          "@type": "@id",
+          "@container": "@graph"
+        }
+      }
+    },
+
+    "EcdsaSecp256k1Signature2019": {
+      "@id": "https://w3id.org/security#EcdsaSecp256k1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "EcdsaSecp256r1Signature2019": {
+      "@id": "https://w3id.org/security#EcdsaSecp256r1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "Ed25519Signature2018": {
+      "@id": "https://w3id.org/security#Ed25519Signature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "RsaSignature2018": {
+      "@id": "https://w3id.org/security#RsaSignature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    }
+  }
+}


### PR DESCRIPTION
- attempting to solve: `loading remote context failed: Dereferencing a URL did not result in a valid JSON-LD context: https://www.w3.org/2018/credentials/v1`
- preload using embed 


### Notes
- do we want to break this out into a separate VC service? 