### PR TITLE
Fiber-friendly error when /unpair gets a signature of length 0

### DIFF
--- a/internal/controllers/helpers/handlers.go
+++ b/internal/controllers/helpers/handlers.go
@@ -245,8 +245,8 @@ var zeroAddr common.Address
 const sigLen = 65
 
 // Ecrecover mimics the ecrecover opcode, returning the address that signed
-// hash with signature. sig must have length 65 and the last byte, the v value,
-// must be 27 or 28.
+// hash with signature. sig must have length 65 and the last byte, the recovery
+// byte usually denoted v, must be 27 or 28.
 func Ecrecover(hash, sig []byte) (common.Address, error) {
 	if len(sig) != sigLen {
 		return zeroAddr, fmt.Errorf("signature has invalid length %d", len(sig))

--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -1109,6 +1109,9 @@ func (udc *UserDevicesController) UnpairAutoPi(c *fiber.Ctx) error {
 	}
 
 	sigBytes := pairReq.Signature
+	if len(sigBytes) != 65 {
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Signature has length %d, not the required 65.", len(sigBytes)))
+	}
 
 	recAddr, err := helpers.Ecrecover(hash, sigBytes)
 	if err != nil {


### PR DESCRIPTION
We could use a more comprehensive treatment of this

# Proposed Changes

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->