### PR TITLE
[SM-395] don't allow vins older than 2008

### DIFF
--- a/internal/rpc/user_devices.go
+++ b/internal/rpc/user_devices.go
@@ -290,6 +290,16 @@ func (s *userDeviceRPCServer) RegisterUserDeviceFromVIN(ctx context.Context, req
 	}
 
 	resp, err := s.deviceDefSvc.DecodeVIN(ctx, vin, "", 0, "")
+
+	if resp.Year < 2008 {
+		s.logger.Warn().
+			Str("vin", vin).
+			Str("user_id", req.UserDeviceId).
+			Msg("VIN is too old")
+
+		return nil, status.Errorf(codes.InvalidArgument, "VIN %s is too old", vin)
+	}
+
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/services/smart_car_api_service_test.go
+++ b/internal/services/smart_car_api_service_test.go
@@ -53,7 +53,7 @@ func Test_parseSmartCarYears(t *testing.T) {
 		{
 			name:     "parse year plus",
 			yearsPtr: &plusYears,
-			want:     []int{2019, 2020, 2021, 2022, 2023},
+			want:     []int{2019, 2020, 2021, 2022, 2023, 2024},
 			wantErr:  false,
 		},
 		{


### PR DESCRIPTION
# Proposed Changes
- Throw error when decoding a VIN and its year is older than 2008
### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->