### PR TITLE
SM-374 AutoPi user device metadata setting for Country and Region

### DIFF
--- a/internal/controllers/webhooks_controller_test.go
+++ b/internal/controllers/webhooks_controller_test.go
@@ -123,7 +123,8 @@ func (s *WebHooksControllerTestSuite) TestPostWebhookSyncCommand() {
 	ddDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Return(integ, nil)
 
 	autoAPISvc.EXPECT().UpdateJob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(autopiJob, nil)
-	autoAPISvc.EXPECT().UpdateState(gomock.Any(), gomock.Any()).Return(nil)
+	ci := constants.FindCountry(ud.CountryCode.String)
+	autoAPISvc.EXPECT().UpdateState(gomock.Any(), gomock.Any(), ud.CountryCode.String, ci.Region).Return(nil)
 
 	udiai := models.UserDeviceAPIIntegration{
 		// create user device api integration

--- a/internal/services/autopi_api_service.go
+++ b/internal/services/autopi_api_service.go
@@ -46,7 +46,7 @@ type AutoPiAPIService interface {
 	GetCommandStatus(ctx context.Context, jobID string) (*AutoPiCommandJob, *models.AutopiJob, error)
 	GetCommandStatusFromAutoPi(deviceID string, jobID string) ([]byte, error)
 	UpdateJob(ctx context.Context, jobID, newState string, result *AutoPiCommandResult) (*models.AutopiJob, error)
-	UpdateState(deviceID string, state string) error
+	UpdateState(deviceID string, state, country, region string) error
 }
 
 type autoPiAPIService struct {
@@ -400,9 +400,16 @@ func (a *autoPiAPIService) GetCommandStatus(ctx context.Context, jobID string) (
 }
 
 // UpdateState calls https://api.dimo.autopi.io/dongle/devices/{DEVICE_ID}/ Note that the deviceID is the autoPi one.
-func (a *autoPiAPIService) UpdateState(deviceID string, state string) error {
+// state is the device pairing state from our end for AP's troubleshooting usage, country and region to be used by AP for region balancing traffic
+func (a *autoPiAPIService) UpdateState(deviceID string, state, country, region string) error {
 	userMetaDataStateInfo := make(map[string]interface{})
 	userMetaDataStateInfo["state"] = state
+	if country != "" {
+		userMetaDataStateInfo["country_code_iso3"] = country
+	}
+	if region != "" {
+		userMetaDataStateInfo["region"] = region
+	}
 
 	userMetaDataInfo := make(map[string]interface{})
 	userMetaDataInfo["user_metadata"] = userMetaDataStateInfo

--- a/internal/services/mocks/autopi_api_service_mock.go
+++ b/internal/services/mocks/autopi_api_service_mock.go
@@ -320,15 +320,15 @@ func (mr *MockAutoPiAPIServiceMockRecorder) UpdateJob(ctx, jobID, newState, resu
 }
 
 // UpdateState mocks base method.
-func (m *MockAutoPiAPIService) UpdateState(deviceID, state string) error {
+func (m *MockAutoPiAPIService) UpdateState(deviceID, state, country, region string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateState", deviceID, state)
+	ret := m.ctrl.Call(m, "UpdateState", deviceID, state, country, region)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateState indicates an expected call of UpdateState.
-func (mr *MockAutoPiAPIServiceMockRecorder) UpdateState(deviceID, state any) *gomock.Call {
+func (mr *MockAutoPiAPIServiceMockRecorder) UpdateState(deviceID, state, country, region any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateState", reflect.TypeOf((*MockAutoPiAPIService)(nil).UpdateState), deviceID, state)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateState", reflect.TypeOf((*MockAutoPiAPIService)(nil).UpdateState), deviceID, state, country, region)
 }


### PR DESCRIPTION
# Proposed Changes
When updating device state in AP user metadata (used for troubleshooting), also set the region/country for them to use for load balancing. 

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->