### PR TITLE
feature/si-2498-merge-accounts

### DIFF
--- a/migrations/20240410120027_merge_accounts_on_addr.sql
+++ b/migrations/20240410120027_merge_accounts_on_addr.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+-- +goose StatementEnd
+SET search_path = devices_api, public;
+UPDATE user_devices 
+    SET 
+        user_id = condensed.user_ids[1]
+FROM 
+    (
+        SELECT
+            ud.owner_address,
+            ARRAY_AGG(distinct ud.user_id) user_ids
+        FROM
+            user_devices ud
+        GROUP BY ud.owner_address
+    ) condensed 
+WHERE condensed.owner_address = user_devices.owner_address;
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+-- +goose StatementEnd


### PR DESCRIPTION
# Proposed Changes
- Make 0x address unique by ensure that each user id is associated with exactly one 0x address
- Merges accounts that do not fit this requirement into a single account

### Notes
- Should this be communicated to users whose accounts will be merged in some way?
- Do we want to have a backup table mapping each user id to the associated device _before_ this merge?
- This will "orphan" some of the users in users api.. we'll probably want to reconcile this at some point to clean out users that are no longer associated with an account 