### PR TITLE
logging-aftermarketDevicePaired

### DIFF
--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -1167,7 +1167,7 @@ func (udc *UserDevicesController) GetAutoPiUnpairMessage(c *fiber.Ctx) error {
 
 	userDeviceID := c.Params("userDeviceID")
 	logger := helpers.GetLogger(c, udc.log)
-	logger.Info().Msg("Got Aftermarket pair request.")
+	logger.Info().Msg("Got Aftermarket unpair request.")
 
 	vnft, autoPiUnit, err := udc.checkUnpairable(c.Context(), udc.DBS().Writer, userDeviceID)
 	if err != nil {

--- a/internal/services/contracts_events_consumer.go
+++ b/internal/services/contracts_events_consumer.go
@@ -421,21 +421,18 @@ func (c *ContractsEventsConsumer) aftermarketDevicePaired(e *ContractEventData) 
 		models.AftermarketDeviceWhere.TokenID.EQ(utils.BigToDecimal(args.AftermarketDeviceNode)),
 	).One(context.TODO(), c.db.DBS().Reader)
 	if err != nil {
-		log.Err(err).Msg("failed to retrieve aftermarket device")
-		return err
+		return fmt.Errorf("failed to retrieve aftermarket device: %w", err)
 	}
 
 	dm, err := c.ddSvc.GetMakeByTokenID(context.TODO(), am.DeviceManufacturerTokenID.Int(nil))
 	if err != nil {
-		log.Err(err).Msg("failed to retrieve manufacturer")
 		return fmt.Errorf("error retrieving manufacturer %d: %w", am.DeviceManufacturerTokenID, err)
 	}
 
 	am.VehicleTokenID = types.NewNullDecimal(utils.BigToDecimal(args.VehicleNode).Big)
 	_, err = am.Update(context.TODO(), c.db.DBS().Writer, boil.Whitelist(models.AftermarketDeviceColumns.VehicleTokenID))
 	if err != nil {
-		log.Err(err).Msg("failed to update aftermarket device")
-		return err
+		return fmt.Errorf("failed to update aftermarket device: %w", err)
 	}
 
 	switch dm.Name {


### PR DESCRIPTION
when compiling vehicles to be burned, there were a few that were not associated with a user device id but were paired on chain. seems like the event was never fully processed. adding these logs so that if this happens in the future we can more easily triangulate where the problem is occurring