### PR TITLE
SI-2653

### DIFF
--- a/internal/controllers/synthetic_devices_controller.go
+++ b/internal/controllers/synthetic_devices_controller.go
@@ -256,7 +256,7 @@ func (sdc *SyntheticDevicesController) MintSyntheticDevice(c *fiber.Ctx) error {
 	}
 
 	if in.TokenId == 0 {
-		return fiber.NewError(fiber.StatusConflict, "Connection type not yet minted.")
+		return fiber.NewError(fiber.StatusConflict, "Integration not yet minted.")
 	}
 
 	vid, ok := ud.TokenID.Int64()

--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -1239,15 +1239,19 @@ func (udc *UserDevicesController) checkPairable(ctx context.Context, exec boil.C
 	ud, err := models.UserDevices(
 		models.UserDeviceWhere.ID.EQ(userDeviceID),
 		qm.Load(models.UserDeviceRels.VehicleTokenAftermarketDevice),
+		qm.Load(models.UserDeviceRels.BurnRequest),
 	).One(ctx, exec)
 	if err != nil {
 		// Access middleware will catch "not found".
 		return nil, nil, err
 	}
 
-	// Vehicle must be minted.
 	if ud.TokenID.IsZero() {
 		return nil, nil, fiber.NewError(fiber.StatusConflict, "Vehicle not yet minted.")
+	}
+
+	if burn := ud.R.BurnRequest; burn != nil && burn.Status != models.MetaTransactionRequestStatusFailed {
+		return nil, nil, fiber.NewError(fiber.StatusConflict, "Vehicle is being burned.")
 	}
 
 	if serial == "" {


### PR DESCRIPTION
Block synthetic device minting and aftermarket device pairing if the vehicle involved is being burned

Also some minor cleanup:

* Use "integration" consistently
* Make the software integration check less hard-coded
* More specific errors when a mint is merely in progress

We still have races lurking.