### PR TITLE
Clean up metatransaction handling

### DIFF
--- a/charts/devices-api/values-prod.yaml
+++ b/charts/devices-api/values-prod.yaml
@@ -50,6 +50,7 @@ env:
   TESLA_TOKEN_URL: https://auth.tesla.com/oauth2/v3/token
   TESLA_FLEET_URL: https://fleet-api.prd.%s.vn.cloud.tesla.com
   META_TRANSACTION_PROCESSOR_GRPC_ADDR: meta-transaction-processor-prod:8086
+  SYNTHETIC_DEVICE_NFT_ADDRESS: "0x4804e8D1661cd1a1e5dDdE1ff458A7f878c0aC6D"
 ingress:
   enabled: true
   className: nginx

--- a/charts/devices-api/values.yaml
+++ b/charts/devices-api/values.yaml
@@ -91,6 +91,7 @@ env:
   TESLA_FLEET_URL: https://fleet-api.prd.%s.vn.cloud.tesla.com
   META_TRANSACTION_PROCESSOR_GRPC_ADDR: meta-transaction-processor-dev:8086
   TESLA_TELEMETRY_HOST_NAME: ingest-tesla.dev.dimo.zone
+  SYNTHETIC_DEVICE_NFT_ADDRESS: "0x78513c8CB4D6B6079f813850376bc9c7fc8aE67f"
   TESLA_TELEMETRY_PORT: 443
   TESLA_TELEMETRY_CA_CERTIFICATE: |
     -----BEGIN CERTIFICATE-----

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -55,6 +55,7 @@ type Settings struct {
 	TokenExchangeJWTKeySetURL         string `yaml:"TOKEN_EXCHANGE_JWK_KEY_SET_URL"`
 	GoogleMapsAPIKey                  string `yaml:"GOOGLE_MAPS_API_KEY"`
 	VehicleNFTAddress                 string `yaml:"VEHICLE_NFT_ADDRESS"`
+	SyntheticDeviceNFTAddress         string `yaml:"SYNTHETIC_DEVICE_NFT_ADDRESS"`
 	ContractsEventTopic               string `yaml:"CONTRACT_EVENT_TOPIC"`
 	AutoPiNFTImage                    string `yaml:"AUTOPI_NFT_IMAGE"`
 	MacaronNFTImage                   string `yaml:"MACARON_NFT_IMAGE"`

--- a/internal/services/contracts_events_consumer.go
+++ b/internal/services/contracts_events_consumer.go
@@ -169,14 +169,6 @@ func (c *ContractsEventsConsumer) processEvent(ctx context.Context, event *share
 	return nil
 }
 
-type PrivilegeArgs struct {
-	TokenID     string
-	Version     int64
-	PrivilegeID int64  `mapstructure:"privId"`
-	UserAddress string `mapstructure:"user"`
-	ExpiresAt   string `mapstructure:"expires"`
-}
-
 func (c *ContractsEventsConsumer) routeTransferEvent(ctx context.Context, e *ContractEventData) error {
 	switch e.Contract {
 	case common.HexToAddress(c.settings.AftermarketDeviceContractAddress):

--- a/internal/services/contracts_events_consumer.go
+++ b/internal/services/contracts_events_consumer.go
@@ -194,8 +194,8 @@ func (c *ContractsEventsConsumer) handleSyntheticTransfer(ctx context.Context, e
 		return err
 	}
 
-	// Only interested in burns. For other transfers, synthetics transfer together with the
-	// vehicle, so no need to track ownership.
+	// Only interested in burns. Mints are handled as meta-transcations and for all other
+	// transfers, synthetics transfer together with the vehicle, so no need to track ownership.
 	if !IsZeroAddress(args.To) {
 		return nil
 	}

--- a/internal/services/contracts_events_consumer.go
+++ b/internal/services/contracts_events_consumer.go
@@ -10,25 +10,23 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DIMO-Network/shared/dbtypes"
-	"github.com/DIMO-Network/shared/kafka"
-
 	"github.com/DIMO-Network/devices-api/internal/config"
 	"github.com/DIMO-Network/devices-api/internal/constants"
 	"github.com/DIMO-Network/devices-api/internal/contracts"
 	"github.com/DIMO-Network/devices-api/internal/services/dex"
 	"github.com/DIMO-Network/devices-api/internal/utils"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/DIMO-Network/devices-api/models"
 	"github.com/DIMO-Network/shared"
 	"github.com/DIMO-Network/shared/db"
+	"github.com/DIMO-Network/shared/dbtypes"
+	"github.com/DIMO-Network/shared/kafka"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/types"
+	"google.golang.org/protobuf/proto"
 )
 
 type Integration interface {
@@ -222,7 +220,7 @@ func (c *ContractsEventsConsumer) handleSyntheticTransfer(ctx context.Context, e
 		return err
 	}
 
-	c.log.Info().Int64("syntheticDeviceTokenId", args.TokenId.Int64()).Msg("Burned synthetic device.")
+	c.log.Info().Int64("syntheticDeviceTokenId", args.TokenId.Int64()).Str("owner", args.From.Hex()).Msg("Burned synthetic device.")
 
 	return nil
 }
@@ -269,7 +267,7 @@ func (c *ContractsEventsConsumer) handleVehicleTransfer(ctx context.Context, e *
 			return err
 		}
 
-		c.log.Info().Int64("vehicleTokenId", args.TokenId.Int64()).Msg("Burned vehicle.")
+		c.log.Info().Int64("vehicleTokenId", args.TokenId.Int64()).Str("owner", args.From.Hex()).Msg("Burned vehicle.")
 	} else {
 		// Faking a user id for a web3 user with the new owner address.
 		s := dex.IDTokenSubject{
@@ -289,7 +287,7 @@ func (c *ContractsEventsConsumer) handleVehicleTransfer(ctx context.Context, e *
 			return err
 		}
 
-		c.log.Info().Int64("vehicleTokenId", args.TokenId.Int64()).Str("ownerAddress", args.To.Hex()).Msg("Transferred vehicle.")
+		c.log.Info().Int64("vehicleTokenId", args.TokenId.Int64()).Msgf("Transferred vehicle from %s to %s.", args.From, args.To)
 	}
 
 	return tx.Commit()

--- a/internal/services/contracts_events_consumer_test.go
+++ b/internal/services/contracts_events_consumer_test.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -769,129 +768,6 @@ func privilegeEventsPayloadFactory(from, to int, eventName string, exp int64, dI
 		})
 	}
 	return res
-}
-
-func Test_VehicleNodeBurn_MetaTxID(t *testing.T) {
-	ctx := context.Background()
-	pdb, container := test.StartContainerDatabase(ctx, t, migrationsDirRelPath)
-	defer container.Terminate(ctx) //nolint
-
-	logger := zerolog.Nop()
-	settings := &config.Settings{DIMORegistryChainID: 1, DIMORegistryAddr: "0x881d40237659c251811cec9c364ef91dc08d300c"}
-
-	mintReq := models.MetaTransactionRequest{
-		ID:     ksuid.New().String(),
-		Status: models.MetaTransactionRequestStatusConfirmed,
-	}
-	assert.NoError(t, mintReq.Insert(context.TODO(), pdb.DBS().Writer, boil.Infer()))
-
-	burnReq := models.MetaTransactionRequest{
-		ID:     ksuid.New().String(),
-		Status: models.MetaTransactionRequestStatusMined,
-	}
-	assert.NoError(t, burnReq.Insert(context.TODO(), pdb.DBS().Writer, boil.Infer()))
-
-	ud := models.UserDevice{
-		ID:                 ksuid.New().String(),
-		UserID:             ksuid.New().String(),
-		DeviceDefinitionID: ksuid.New().String(),
-		MintRequestID:      null.StringFrom(mintReq.ID),
-		OwnerAddress:       null.BytesFrom(common.FromHex("0xdafea492d9c6733ae3d56b7ed1adb60692c98bc5")),
-		TokenID:            types.NewNullDecimal(decimal.New(5, 0)),
-		BurnRequestID:      null.StringFrom(burnReq.ID),
-	}
-	_ = ud.Insert(ctx, pdb.DBS().Writer, boil.Infer())
-
-	consumer := NewContractsEventsConsumer(pdb, &logger, settings, nil, nil, nil)
-
-	event, err := marshalMockPayload(fmt.Sprintf(`{
-		"type": "zone.dimo.contract.event",
-		"source": "chain/%d",
-		"data": {
-			"contract": "%s",
-			"eventName": "%s",
-			"chainId": %d,
-			"arguments": {
-			"vehicleNode": %s,
-			"owner": "%s"
-			}
-		}
-	}`,
-		settings.DIMORegistryChainID,
-		settings.DIMORegistryAddr,
-		VehicleNodeBurned.String(),
-		settings.DIMORegistryChainID,
-		ud.TokenID.String(),
-		common.BytesToAddress(ud.OwnerAddress.Bytes)))
-	assert.NoError(t, err)
-
-	err = consumer.processEvent(ctx, event)
-	if err != nil {
-		t.Errorf("failed to process event: %v", err)
-	}
-
-	assert.NoError(t, burnReq.Reload(ctx, pdb.DBS().Reader))
-	assert.Equal(t, models.MetaTransactionRequestStatusConfirmed, burnReq.Status)
-	assert.NotNil(t, burnReq.Hash)
-
-	assert.ErrorIs(t, ud.Reload(ctx, pdb.DBS().Reader), sql.ErrNoRows)
-	assert.ErrorIs(t, ud.Reload(ctx, pdb.DBS().Reader), sql.ErrNoRows)
-}
-
-func Test_VehicleNodeBurn_NoMetaTxID(t *testing.T) {
-	ctx := context.Background()
-	pdb, container := test.StartContainerDatabase(ctx, t, migrationsDirRelPath)
-	defer container.Terminate(ctx) //nolint
-
-	logger := zerolog.Nop()
-	settings := &config.Settings{DIMORegistryChainID: 1, DIMORegistryAddr: "0x881d40237659c251811cec9c364ef91dc08d300c"}
-
-	mintReq := models.MetaTransactionRequest{
-		ID:     ksuid.New().String(),
-		Status: models.MetaTransactionRequestStatusConfirmed,
-	}
-	assert.NoError(t, mintReq.Insert(context.TODO(), pdb.DBS().Writer, boil.Infer()))
-
-	ud := models.UserDevice{
-		ID:                 ksuid.New().String(),
-		UserID:             ksuid.New().String(),
-		DeviceDefinitionID: ksuid.New().String(),
-		MintRequestID:      null.StringFrom(mintReq.ID),
-		OwnerAddress:       null.BytesFrom(common.FromHex("0xdafea492d9c6733ae3d56b7ed1adb60692c98bc5")),
-		TokenID:            types.NewNullDecimal(decimal.New(13, 0)),
-	}
-	_ = ud.Insert(ctx, pdb.DBS().Writer, boil.Infer())
-
-	consumer := NewContractsEventsConsumer(pdb, &logger, settings, nil, nil, nil)
-
-	event, err := marshalMockPayload(fmt.Sprintf(`{
-		"type": "zone.dimo.contract.event",
-		"source": "chain/%d",
-		"data": {
-			"contract": "%s",
-			"eventName": "%s",
-			"chainId": %d,
-			"arguments": {
-			"vehicleNode": %s,
-			"owner": "%s"
-			}
-		}
-	}`,
-		settings.DIMORegistryChainID,
-		settings.DIMORegistryAddr,
-		VehicleNodeBurned.String(),
-		settings.DIMORegistryChainID,
-		ud.TokenID.String(),
-		common.BytesToAddress(ud.OwnerAddress.Bytes)))
-	assert.NoError(t, err)
-
-	err = consumer.processEvent(ctx, event)
-	if err != nil {
-		t.Errorf("failed to process event: %v", err)
-	}
-
-	assert.ErrorIs(t, ud.Reload(ctx, pdb.DBS().Reader), sql.ErrNoRows)
-	assert.ErrorIs(t, ud.Reload(ctx, pdb.DBS().Reader), sql.ErrNoRows)
 }
 
 func initCEventsTestHelper(t *testing.T) cEventsTestHelper {

--- a/internal/services/registry/storage.go
+++ b/internal/services/registry/storage.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/DIMO-Network/shared"
@@ -11,14 +12,13 @@ import (
 	"github.com/DIMO-Network/devices-api/internal/services"
 	"github.com/DIMO-Network/devices-api/models"
 	"github.com/DIMO-Network/shared/db"
-	"github.com/ericlagergren/decimal"
+	"github.com/DIMO-Network/shared/dbtypes"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog"
 	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
-	"github.com/volatiletech/sqlboiler/v4/types"
 )
 
 type StatusProcessor interface {
@@ -46,10 +46,6 @@ func (p *proc) Handle(ctx context.Context, data *ceData) error {
 		models.MetaTransactionRequestWhere.ID.EQ(data.RequestID),
 		// This is really ugly. We should probably link back to the type instead of doing this.
 		qm.Load(models.MetaTransactionRequestRels.MintRequestUserDevice),
-		qm.Load(models.MetaTransactionRequestRels.BurnRequestUserDevice),
-		qm.Load(models.MetaTransactionRequestRels.ClaimMetaTransactionRequestAftermarketDevice),
-		qm.Load(models.MetaTransactionRequestRels.PairRequestAftermarketDevice),
-		qm.Load(models.MetaTransactionRequestRels.UnpairRequestAftermarketDevice),
 		qm.Load(models.MetaTransactionRequestRels.MintRequestSyntheticDevice),
 		qm.Load(models.MetaTransactionRequestRels.BurnRequestSyntheticDevice),
 	).One(context.Background(), p.DB().Reader)
@@ -78,21 +74,22 @@ func (p *proc) Handle(ctx context.Context, data *ceData) error {
 
 	switch {
 	case mtr.R.MintRequestUserDevice != nil:
-		for _, l1 := range data.Transaction.Logs {
-			if l1.Topics[0] == vehicleMintedEvent.ID {
-				out := new(contracts.RegistryVehicleNodeMinted)
-				err := p.parseLog(out, vehicleMintedEvent, l1)
+		for _, logs := range data.Transaction.Logs {
+			if logs.Topics[0] == vehicleMintedEvent.ID {
+				var event contracts.RegistryVehicleNodeMinted
+				err := p.parseLog(&event, vehicleMintedEvent, logs)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to parse VehicleNodeMinted event: %w", err)
 				}
 
 				ud := mtr.R.MintRequestUserDevice
+				cols := models.UserDeviceColumns
 
-				ud.TokenID = types.NewNullDecimal(new(decimal.Big).SetBigMantScale(out.TokenId, 0))
-				ud.OwnerAddress = null.BytesFrom(out.Owner.Bytes())
-				_, err = ud.Update(ctx, p.DB().Writer, boil.Whitelist(models.UserDeviceColumns.TokenID, models.UserDeviceColumns.OwnerAddress))
+				ud.TokenID = dbtypes.NullIntToDecimal(event.TokenId)
+				ud.OwnerAddress = null.BytesFrom(event.Owner.Bytes())
+				_, err = ud.Update(ctx, p.DB().Writer, boil.Whitelist(cols.TokenID, cols.OwnerAddress))
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to update vehicle record: %w", err)
 				}
 
 				p.Eventer.Emit(&shared.CloudEvent[any]{ //nolint
@@ -107,74 +104,64 @@ func (p *proc) Handle(ctx context.Context, data *ceData) error {
 							VIN: ud.VinIdentifier.String,
 						},
 						NFT: services.UserDeviceEventNFT{
-							TokenID: out.TokenId,
-							Owner:   out.Owner,
+							TokenID: event.TokenId,
+							Owner:   event.Owner,
 							TxHash:  common.HexToHash(data.Transaction.Hash),
 						},
 					},
 				})
 
-				logger.Info().Str("userDeviceId", mtr.R.MintRequestUserDevice.ID).Msg("Vehicle minted.")
-			} else if l1.Topics[0] == syntheticDeviceMintedEvent.ID {
+				logger.Info().Str("userDeviceId", mtr.R.MintRequestUserDevice.ID).Int64("vehicleTokenId", event.TokenId.Int64()).Msg("Vehicle minted.")
+			} else if logs.Topics[0] == syntheticDeviceMintedEvent.ID {
 				// We must be doing a combined vehicle and SD mint. This always comes second.
-				out := new(contracts.RegistrySyntheticDeviceNodeMinted)
-
-				sd := mtr.R.MintRequestSyntheticDevice
-				if sd == nil {
-					logger.Err(err).Msg("Impossible")
-					return nil
+				var event contracts.RegistrySyntheticDeviceNodeMinted
+				err := p.parseLog(&event, syntheticDeviceMintedEvent, logs)
+				if err != nil {
+					return fmt.Errorf("failed to parse SyntheticDeviceNodeMinted event: %w", err)
 				}
 
-				err := p.parseLog(out, syntheticDeviceMintedEvent, l1)
-				if err != nil {
-					return err
+				cols := models.SyntheticDeviceColumns
+				sd := mtr.R.MintRequestSyntheticDevice
+				if sd == nil {
+					return fmt.Errorf("vehicle mint has a SyntheticDeviceNodeMinted log but there's no synthetic device attached to the meta-transaction")
 				}
 
 				sd.VehicleTokenID = mtr.R.MintRequestUserDevice.TokenID
-				sd.TokenID = types.NewNullDecimal(new(decimal.Big).SetBigMantScale(out.SyntheticDeviceNode, 0))
-				_, err = sd.Update(ctx, p.DB().Writer, boil.Infer())
+				sd.TokenID = dbtypes.NullIntToDecimal(event.SyntheticDeviceNode)
+				_, err = sd.Update(ctx, p.DB().Writer, boil.Whitelist(cols.VehicleTokenID, cols.TokenID))
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to update synthetic device record: %w", err)
 				}
 			}
 		}
-	case mtr.R.BurnRequestUserDevice != nil:
-		// Handled in contract event consumer.
-	case mtr.R.ClaimMetaTransactionRequestAftermarketDevice != nil:
-		// Handled in the contract event consumer.
-	case mtr.R.PairRequestAftermarketDevice != nil:
-		// Handled in the contract event consumer.
-	case mtr.R.UnpairRequestAftermarketDevice != nil:
-		// Handled in the contract event consumer.
+	// It's very important that this be after the case for VehicleNodeMinted.
 	case mtr.R.MintRequestSyntheticDevice != nil:
-		// It's very important that this be after the case for VehicleNodeMinted.
-		for _, l1 := range data.Transaction.Logs {
-			if l1.Topics[0] == syntheticDeviceMintedEvent.ID {
-				out := new(contracts.RegistrySyntheticDeviceNodeMinted)
-				err := p.parseLog(out, syntheticDeviceMintedEvent, l1)
+		for _, log := range data.Transaction.Logs {
+			if log.Topics[0] == syntheticDeviceMintedEvent.ID {
+				var event contracts.RegistrySyntheticDeviceNodeMinted
+				err := p.parseLog(&event, syntheticDeviceMintedEvent, log)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to parse SyntheticDeviceNodeMinted event: %w", err)
 				}
 
 				sd := mtr.R.MintRequestSyntheticDevice
-				tkID := types.NewNullDecimal(new(decimal.Big).SetBigMantScale(out.SyntheticDeviceNode, 0))
-				sd.TokenID = tkID
-				if _, err := sd.Update(ctx, p.DB().Writer, boil.Infer()); err != nil {
-					return err
+				sd.TokenID = dbtypes.NullIntToDecimal(event.SyntheticDeviceNode)
+				if _, err := sd.Update(ctx, p.DB().Writer, boil.Whitelist(models.SyntheticDeviceColumns.TokenID)); err != nil {
+					return fmt.Errorf("failed to update synthetic device record: %w", err)
 				}
 			}
 		}
 	case mtr.R.BurnRequestSyntheticDevice != nil:
 		for _, l1 := range data.Transaction.Logs {
 			if l1.Topics[0] == sdBurnEvent.ID {
-				out := new(contracts.RegistrySyntheticDeviceNodeBurned)
-				err := p.parseLog(out, sdBurnEvent, l1)
+				var event contracts.RegistrySyntheticDeviceNodeBurned
+				err := p.parseLog(&event, sdBurnEvent, l1)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to parse SyntheticDeviceNodeBurned event: %w", err)
 				}
 
 				if _, err := mtr.R.BurnRequestSyntheticDevice.Delete(ctx, p.DB().Writer); err != nil {
-					return err
+					return fmt.Errorf("failed to delete synthetic device record: %w", err)
 				}
 			}
 		}

--- a/internal/services/registry/storage.go
+++ b/internal/services/registry/storage.go
@@ -109,7 +109,11 @@ func (p *proc) Handle(ctx context.Context, data *ceData) error {
 					},
 				})
 
-				logger.Info().Str("userDeviceId", mtr.R.MintRequestUserDevice.ID).Int64("vehicleTokenId", event.TokenId.Int64()).Msg("Vehicle minted.")
+				logger.Info().
+					Str("userDeviceId", mtr.R.MintRequestUserDevice.ID).
+					Int64("vehicleTokenId", event.TokenId.Int64()).
+					Str("owner", event.Owner.Hex()).
+					Msg("Vehicle minted.")
 			} else if logs.Topics[0] == syntheticDeviceMintedEvent.ID {
 				// We must be doing a combined vehicle and SD mint. This always comes second.
 				var event contracts.RegistrySyntheticDeviceNodeMinted
@@ -130,6 +134,12 @@ func (p *proc) Handle(ctx context.Context, data *ceData) error {
 				if err != nil {
 					return fmt.Errorf("failed to update synthetic device record: %w", err)
 				}
+
+				logger.Info().
+					Int64("vehicleTokenId", event.VehicleNode.Int64()).
+					Int64("syntheticDeviceTokenId", event.SyntheticDeviceNode.Int64()).
+					Str("owner", event.Owner.Hex()).
+					Msg("Synthetic device minted.")
 			}
 		}
 	// It's very important that this be after the case for VehicleNodeMinted.
@@ -147,6 +157,12 @@ func (p *proc) Handle(ctx context.Context, data *ceData) error {
 				if _, err := sd.Update(ctx, p.DB().Writer, boil.Whitelist(models.SyntheticDeviceColumns.TokenID)); err != nil {
 					return fmt.Errorf("failed to update synthetic device record: %w", err)
 				}
+
+				logger.Info().
+					Int64("vehicleTokenId", event.VehicleNode.Int64()).
+					Int64("syntheticDeviceTokenId", event.SyntheticDeviceNode.Int64()).
+					Str("owner", event.Owner.Hex()).
+					Msg("Synthetic device minted.")
 			}
 		}
 	}


### PR DESCRIPTION
* Longer variable names, more and more standardized logging
* Handle synthetic burns as contract events
* Merge the two contract event handlers handling vehicle burning