### PR TITLE
SI-2726 Emit privacy zones by vehicle id

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           version: latest
           only-new-issues: false
-          args: --modules-download-mode=readonly --timeout=5m
+          args: --modules-download-mode=readonly --timeout=10m

--- a/charts/devices-api/values.yaml
+++ b/charts/devices-api/values.yaml
@@ -226,6 +226,14 @@ kafka:
         min.compaction.lag.ms: '3600000'
         min.cleanable.dirty.ratio: '0.01'
         delete.retention.ms: '3600000'
+    - name: table.device.privacyfence.v2
+      config:
+        segment.ms: '3600000'
+        compression.type: producer
+        cleanup.policy: compact
+        min.compaction.lag.ms: '3600000'
+        min.cleanable.dirty.ratio: '0.01'
+        delete.retention.ms: '3600000'
     - name: devices-vin-fraud-table
       config:
         segment.ms: '3600000'

--- a/charts/devices-api/values.yaml
+++ b/charts/devices-api/values.yaml
@@ -120,6 +120,7 @@ env:
     -----END CERTIFICATE-----
   IPFS_URL: https://assets.dev.dimo.xyz/ipfs
   SD_INFO_TOPIC: table.task.synthetic.fill
+  PRIVACY_FENCE_TOPIC_V2: table.device.privacyfence.v2
 service:
   type: ClusterIP
   ports:

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -25,6 +25,7 @@ type Settings struct {
 	KafkaBrokers         string      `yaml:"KAFKA_BROKERS"`
 	// DeviceStatusTopic                 string      `yaml:"DEVICE_STATUS_TOPIC"`
 	PrivacyFenceTopic                 string `yaml:"PRIVACY_FENCE_TOPIC"`
+	PrivacyFenceTopicV2               string `yaml:"PRIVACY_FENCE_TOPIC_V2"`
 	TaskRunNowTopic                   string `yaml:"TASK_RUN_NOW_TOPIC"`
 	TaskStopTopic                     string `yaml:"TASK_STOP_TOPIC"`
 	TaskCredentialTopic               string `yaml:"TASK_CREDENTIAL_TOPIC"`

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -363,9 +363,12 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
-// createDeviceList checks that the listed vehicles exist, are minted, and are owned
-// by the user. It also performs deduplication, and returns a list of the database
-// objects for the vehicles. Errors returned from this function are safe to return to Fiber.
+// createDeviceList checks that the given user can attach geofences to the vehicles
+// with the given ids, and returns a slice of database objects for those vehicles.
+//
+// Specifically, the vehicles must exist, be minted, and be owned by the user. This function
+// performs deduplication, so the length of the output slice may not match that of
+// the input slice. Errors returned from this function are safe to return to Fiber.
 func (g *GeofencesController) createDeviceList(ctx context.Context, tx *sql.Tx, userID string, userDeviceIDs []string) ([]*models.UserDevice, error) {
 	out := make([]*models.UserDevice, 0, len(userDeviceIDs))
 

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -363,9 +363,9 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
-// createDeviceList checks that the user is allowed to attach a geofence to user devices specified
-// by the given id list. It also deduplicates devices and makes sure that they are minted. Errors
-// returned from this function are safe to return to Fiber.
+// createDeviceList checks that the listed vehicles exist, are minted, and are owned
+// by the user. It also performs deduplication, and returns a list of the database
+// objects for the vehicles. Errors returned from this function are safe to return to Fiber.
 func (g *GeofencesController) createDeviceList(ctx context.Context, tx *sql.Tx, userID string, userDeviceIDs []string) ([]*models.UserDevice, error) {
 	out := make([]*models.UserDevice, 0, len(userDeviceIDs))
 

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -313,20 +313,18 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 		return err
 	}
 
-	// Set will contain vehicles that were previously attached to this fence and vehicles that
-	// will be attached to this fence.
-	affectedDeviceIDs := shared.NewStringSet()
+	// This list will contain the vehicles that were previously attached to this fence and the
+	// vehicles that will be attached to this fence.
+	affectedDeviceIDs := update.UserDeviceIDs
 
 	for _, rel := range geofence.R.UserDeviceToGeofences {
-		affectedDeviceIDs.Add(rel.UserDeviceID)
-	}
-	for _, newUD := range update.UserDeviceIDs {
-		affectedDeviceIDs.Add(newUD)
+		affectedDeviceIDs = append(affectedDeviceIDs, rel.UserDeviceID)
 	}
 
 	geofence.Name = update.Name
 	geofence.Type = update.Type
 	geofence.H3Indexes = update.H3Indexes
+
 	_, err = geofence.Update(c.Context(), tx, boil.Whitelist(
 		models.GeofenceColumns.Name,
 		models.GeofenceColumns.Type,
@@ -336,7 +334,7 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 		return errors.Wrap(err, "error updating geofence")
 	}
 
-	uds, err := g.createDeviceList(c.Context(), tx, userID, affectedDeviceIDs.Slice())
+	uds, err := g.createDeviceList(c.Context(), tx, userID, affectedDeviceIDs)
 	if err != nil {
 		return err
 	}

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -392,6 +392,7 @@ func (g *GeofencesController) createDeviceList(ctx context.Context, tx *sql.Tx, 
 			continue
 		}
 
+		// TODO(elffjs): Respect wallet ownership too.
 		ud, err := models.UserDevices(
 			models.UserDeviceWhere.ID.EQ(id),
 			models.UserDeviceWhere.UserID.EQ(userID),

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -345,7 +345,10 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 			return errors.Wrapf(err, "error upserting user_device_to_geofence")
 		}
 
-		g.EmitPrivacyFenceUpdates(c.Context(), tx, ud.ID, ud.TokenID)
+		err = g.EmitPrivacyFenceUpdates(c.Context(), tx, ud.ID, ud.TokenID)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = tx.Commit()
@@ -360,7 +363,7 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 // by the given id list. It also deduplicates devices and makes sure that they are minted. Errors
 // returned from this function are safe to return to Fiber.
 func (g *GeofencesController) createDeviceList(ctx context.Context, tx *sql.Tx, userID string, userDeviceIDs []string) ([]*models.UserDevice, error) {
-	var out []*models.UserDevice
+	out := make([]*models.UserDevice, 0, len(userDeviceIDs))
 
 	seenIDs := shared.NewStringSet()
 

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -338,17 +338,21 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	for _, ud := range uds {
+
+	for _, uID := range update.UserDeviceIDs {
 		geoToUser := models.UserDeviceToGeofence{
-			UserDeviceID: ud.ID,
+			UserDeviceID: uID,
 			GeofenceID:   geofence.ID,
 		}
+
 		err = geoToUser.Upsert(c.Context(), tx, true,
 			[]string{models.UserDeviceToGeofenceColumns.UserDeviceID, models.UserDeviceToGeofenceColumns.GeofenceID}, boil.Infer(), boil.Infer())
 		if err != nil {
 			return errors.Wrapf(err, "error upserting user_device_to_geofence")
 		}
+	}
 
+	for _, ud := range uds {
 		err = g.EmitPrivacyFenceUpdates(c.Context(), tx, ud.ID, ud.TokenID)
 		if err != nil {
 			return err

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -186,7 +186,7 @@ func (g *GeofencesController) EmitPrivacyFenceUpdates(ctx context.Context, db bo
 	}
 
 	if !tokenID.IsZero() {
-		msg = &sarama.ProducerMessage{
+		msg := &sarama.ProducerMessage{
 			Topic: g.Settings.PrivacyFenceTopicV2,
 			Key:   sarama.StringEncoder(tokenID.String()),
 			Value: value,
@@ -357,8 +357,8 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 }
 
 // createDeviceList checks that the user is allowed to attach a geofence to user devices specified
-// by the given id list. It also deduplicates from this list and makes sure that the devices
-// are minted. Errors returned from this function are safe to return to Fiber.
+// by the given id list. It also deduplicates devices and makes sure that they are minted. Errors
+// returned from this function are safe to return to Fiber.
 func (g *GeofencesController) createDeviceList(ctx context.Context, tx *sql.Tx, userID string, userDeviceIDs []string) ([]*models.UserDevice, error) {
 	var out []*models.UserDevice
 

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -313,9 +313,15 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 		return err
 	}
 
+	// Set will contain vehicles that were previously attached to this fence and vehicles that
+	// will be attached to this fence.
 	affectedDeviceIDs := shared.NewStringSet()
+
 	for _, rel := range geofence.R.UserDeviceToGeofences {
 		affectedDeviceIDs.Add(rel.UserDeviceID)
+	}
+	for _, newUD := range update.UserDeviceIDs {
+		affectedDeviceIDs.Add(newUD)
 	}
 
 	geofence.Name = update.Name
@@ -330,7 +336,7 @@ func (g *GeofencesController) Update(c *fiber.Ctx) error {
 		return errors.Wrap(err, "error updating geofence")
 	}
 
-	uds, err := g.createDeviceList(c.Context(), tx, userID, update.UserDeviceIDs)
+	uds, err := g.createDeviceList(c.Context(), tx, userID, affectedDeviceIDs.Slice())
 	if err != nil {
 		return err
 	}

--- a/internal/controllers/geofences_controller_test.go
+++ b/internal/controllers/geofences_controller_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	"github.com/DIMO-Network/shared/db"
+	"github.com/ericlagergren/decimal"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"github.com/volatiletech/sqlboiler/v4/types"
 
 	"github.com/DIMO-Network/devices-api/internal/config"
 	mock_services "github.com/DIMO-Network/devices-api/internal/services/mocks"
@@ -119,6 +122,9 @@ func (s *GeofencesControllerTestSuite) TestPostGeofence() {
 	app := fiber.New()
 	app.Post("/user/geofences", test.AuthInjectorTestHandler(injectedUserID), c.Create)
 	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, ksuid.New().String(), nil, "", s.pdb)
+	ud.TokenID = types.NewNullDecimal(decimal.New(1, 0))
+	_, err := ud.Update(s.ctx, s.pdb.DBS().Writer, boil.Infer())
+	s.Require().NoError(err)
 	req := CreateGeofence{
 		Name:          "Home",
 		Type:          "PrivacyFence",

--- a/internal/controllers/geofences_controller_test.go
+++ b/internal/controllers/geofences_controller_test.go
@@ -37,11 +37,11 @@ type partialFenceCloudEvent struct {
 	} `json:"data"`
 }
 
-func checkForDeviceAndH3(userDeviceID string, h3Indexes []string) func(*sarama.ProducerMessage) error {
+func checkForDeviceAndH3(key string, h3Indexes []string) func(*sarama.ProducerMessage) error {
 	return func(msg *sarama.ProducerMessage) error {
 		kb, _ := msg.Key.Encode()
-		if string(kb) != userDeviceID {
-			return fmt.Errorf("expected message to be keyed with %s but got %s", userDeviceID, string(kb))
+		if string(kb) != key {
+			return fmt.Errorf("expected message to be keyed with %s but got %s", key, string(kb))
 		}
 
 		if len(h3Indexes) == 0 {
@@ -134,6 +134,7 @@ func (s *GeofencesControllerTestSuite) TestPostGeofence() {
 	j, _ := json.Marshal(req)
 
 	producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(checkForDeviceAndH3(ud.ID, []string{"123", "321"}))
+	producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(checkForDeviceAndH3(ud.TokenID.String(), []string{"123", "321"}))
 
 	request := test.BuildRequest("POST", "/user/geofences", string(j))
 	response, _ := app.Test(request)
@@ -146,6 +147,7 @@ func (s *GeofencesControllerTestSuite) TestPostGeofence() {
 	assert.Len(s.T(), createdID, 27)
 
 	producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(checkForDeviceAndH3(ud.ID, []string{"123", "321"}))
+	producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(checkForDeviceAndH3(ud.TokenID.String(), []string{"123", "321"}))
 
 	// create one without h3 indexes required
 	req = CreateGeofence{
@@ -233,10 +235,13 @@ func (s *GeofencesControllerTestSuite) TestPutGeofence() {
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "escaped", 2020, nil)
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionsByIDs(gomock.Any(), []string{dd[0].DeviceDefinitionId}).Return(dd, nil)
 	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
+	ud.TokenID = types.NewNullDecimal(decimal.New(1, 0))
+	_, err := ud.Update(s.ctx, s.pdb.DBS().Writer, boil.Infer())
+	s.Require().NoError(err)
+
 	gf := test.SetupCreateGeofence(s.T(), injectedUserID, "something", &ud, s.pdb)
 
 	// The fence is being detached from the device and it has type TriggerEntry anyway.
-	producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(checkForDeviceAndH3(ud.ID, []string{}))
 
 	req := CreateGeofence{
 		Name:          "School",

--- a/internal/controllers/geofences_controller_test.go
+++ b/internal/controllers/geofences_controller_test.go
@@ -242,6 +242,8 @@ func (s *GeofencesControllerTestSuite) TestPutGeofence() {
 	gf := test.SetupCreateGeofence(s.T(), injectedUserID, "something", &ud, s.pdb)
 
 	// The fence is being detached from the device and it has type TriggerEntry anyway.
+	producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(checkForDeviceAndH3(ud.ID, []string{}))
+	producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(checkForDeviceAndH3(ud.TokenID.String(), []string{}))
 
 	req := CreateGeofence{
 		Name:          "School",


### PR DESCRIPTION
We already emit privacy fence updates to `table.device.privacyfence`, keyed by user device id, when a fence is modified or when a fence is attached to or detached from a vehicle. Here we also emit the same messages to `table.device.privacyfence.v2`, keyed by vehicle token id.

Asides

* You can't attach or detach a fence from a vehicle that isn't minted.
* Fixes a [long-standing bug](https://github.com/DIMO-Network/devices-api/pull/356/files#diff-363f4238e0f752e79e0a6f611107a294ae1e44b37ee93c2d1705216563c96c66L332): anyone could attach a privacy fence they own to any vehicle, even one they did not own.

Downsides

* If you have an un-minted vehicle that already has fences attached (under the old controller), and you later mint it, we don't emit updates.

I want to clean this file up more, but this PR is already large.