### PR TITLE
VIN patch endpoint add set the country code and protocol

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1650,7 +1650,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "updates the VIN on the user device record",
+                "description": "Deprecated. updates the VIN on the user device record",
                 "consumes": [
                     "application/json"
                 ],
@@ -2142,7 +2142,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "updates the VIN on the user device record",
+                "description": "updates the VIN on the user device record. Can optionally also update the protocol and the country code",
                 "consumes": [
                     "application/json"
                 ],
@@ -3265,6 +3265,14 @@ const docTemplate = `{
                 "vin"
             ],
             "properties": {
+                "canProtocol": {
+                    "description": "CANProtocol optional. Numeric style made up protocol. 6 = CAN11_500, 7 = CAN29_500, 66/77 are some UDS thing etc",
+                    "type": "string"
+                },
+                "countryCode": {
+                    "description": "CountryCode optional. Is set on the user device record",
+                    "type": "string"
+                },
                 "signature": {
                     "description": "Signature is the hex-encoded result of the AutoPi signing the VIN. It must\nbe present to verify the VIN.",
                     "type": "string",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1642,7 +1642,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "updates the VIN on the user device record",
+                "description": "Deprecated. updates the VIN on the user device record",
                 "consumes": [
                     "application/json"
                 ],
@@ -2134,7 +2134,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "updates the VIN on the user device record",
+                "description": "updates the VIN on the user device record. Can optionally also update the protocol and the country code",
                 "consumes": [
                     "application/json"
                 ],
@@ -3257,6 +3257,14 @@
                 "vin"
             ],
             "properties": {
+                "canProtocol": {
+                    "description": "CANProtocol optional. Numeric style made up protocol. 6 = CAN11_500, 7 = CAN29_500, 66/77 are some UDS thing etc",
+                    "type": "string"
+                },
+                "countryCode": {
+                    "description": "CountryCode optional. Is set on the user device record",
+                    "type": "string"
+                },
                 "signature": {
                     "description": "Signature is the hex-encoded result of the AutoPi signing the VIN. It must\nbe present to verify the VIN.",
                     "type": "string",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -768,6 +768,13 @@ definitions:
     type: object
   internal_controllers.UpdateVINReq:
     properties:
+      canProtocol:
+        description: CANProtocol optional. Numeric style made up protocol. 6 = CAN11_500,
+          7 = CAN29_500, 66/77 are some UDS thing etc
+        type: string
+      countryCode:
+        description: CountryCode optional. Is set on the user device record
+        type: string
       signature:
         description: |-
           Signature is the hex-encoded result of the AutoPi signing the VIN. It must
@@ -1862,7 +1869,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: updates the VIN on the user device record
+      description: Deprecated. updates the VIN on the user device record
       parameters:
       - description: VIN
         in: body
@@ -2270,7 +2277,8 @@ paths:
     patch:
       consumes:
       - application/json
-      description: updates the VIN on the user device record
+      description: updates the VIN on the user device record. Can optionally also
+        update the protocol and the country code
       parameters:
       - description: token id
         in: path

--- a/internal/controllers/nft_controller_test.go
+++ b/internal/controllers/nft_controller_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/big"
-
 	"github.com/DIMO-Network/devices-api/internal/services/registry"
 	"github.com/DIMO-Network/devices-api/internal/test"
 	"github.com/DIMO-Network/devices-api/models"
@@ -20,6 +18,7 @@ import (
 	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"go.uber.org/mock/gomock"
+	"math/big"
 )
 
 func (s *UserDevicesControllerTestSuite) TestGetBurn() {
@@ -131,4 +130,39 @@ func (s *UserDevicesControllerTestSuite) TestPostBurn() {
 
 	s.Require().NotEmpty(ud.BurnRequestID)
 
+}
+
+func (s *UserDevicesControllerTestSuite) TestUpdateVINV2_setCountryAndProtocol() {
+	privKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	addr := crypto.PubkeyToAddress(privKey.PublicKey)
+	//email := "some@email.com"
+	//eth := addr.Hex()
+	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Escape", 2020, nil)
+	s.deviceDefSvc.EXPECT().GetDeviceDefinitionByID(gomock.Any(), dd[0].DeviceDefinitionId).Return(dd[0], nil)
+
+	userDevice := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
+	_ = test.SetupCreateVehicleNFT(s.T(), userDevice, big.NewInt(1), null.BytesFrom(addr.Bytes()), s.pdb)
+
+	input := &UpdateVINReq{
+		VIN:         "4Y1SL65848Z411439",
+		CountryCode: "USA",
+		CANProtocol: "7",
+		Signature:   "",
+	}
+	marshal, _ := json.Marshal(input)
+	request := test.BuildRequest("PATCH", fmt.Sprintf("/vehicle/%s/vin", "1"), string(marshal))
+
+	response, err := s.app.Test(request)
+	s.Require().NoError(err)
+	s.Equal(204, response.StatusCode)
+
+	if err := userDevice.Reload(context.Background(), s.pdb.DBS().Reader); err != nil {
+		s.T().Fatal(err)
+	}
+
+	s.Equal("USA", userDevice.CountryCode.String)
+	s.Equal(`{"canProtocol": "7", "postal_code": null, "powertrainType": "ICE", "geoDecodedCountry": null, "geoDecodedStateProv": null}`,
+		string(userDevice.Metadata.JSON))
+	s.Equal("4Y1SL65848Z411439", userDevice.VinIdentifier.String)
 }

--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -940,7 +940,7 @@ func (udc *UserDevicesController) DeviceOptIn(c *fiber.Ctx) error {
 }
 
 // UpdateVIN godoc
-// @Description updates the VIN on the user device record
+// @Description Deprecated. updates the VIN on the user device record
 // @Tags        user-devices
 // @Produce     json
 // @Accept      json
@@ -950,6 +950,7 @@ func (udc *UserDevicesController) DeviceOptIn(c *fiber.Ctx) error {
 // @Security    BearerAuth
 // @Router      /user/devices/{userDeviceID}/vin [patch]
 func (udc *UserDevicesController) UpdateVIN(c *fiber.Ctx) error {
+	// todo remove this endpoint on next mobile app release
 	udi := c.Params("userDeviceID")
 	logger := helpers.GetLogger(c, udc.log).With().Str("route", c.Route().Name).Logger()
 	var req UpdateVINReq
@@ -1665,6 +1666,10 @@ type UpdateVINReq struct {
 	// VIN is a vehicle identification number. At the very least, it must be
 	// 17 characters in length and contain only letters and numbers.
 	VIN string `json:"vin" example:"4Y1SL65848Z411439" validate:"required"`
+	// CountryCode optional. Is set on the user device record
+	CountryCode string `json:"countryCode"`
+	// CANProtocol optional. Numeric style made up protocol. 6 = CAN11_500, 7 = CAN29_500, 66/77 are some UDS thing etc
+	CANProtocol string `json:"canProtocol"`
 	// Signature is the hex-encoded result of the AutoPi signing the VIN. It must
 	// be present to verify the VIN.
 	Signature string `json:"signature" example:"16b15f88bbd2e0a22d1d0084b8b7080f2003ea83eab1a00f80d8c18446c9c1b6224f17aa09eaf167717ca4f355bb6dc94356e037edf3adf6735a86fc3741f5231b" validate:"optional"`


### PR DESCRIPTION
# Proposed Changes
In new pairing flow this is the only place we could set the country code and protocol, so adding it here

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->