### PR TITLE
Tidy

### DIFF
--- a/.github/workflows/buildpushdev.yml
+++ b/.github/workflows/buildpushdev.yml
@@ -8,7 +8,7 @@ jobs:
   build_test:
     # The type of runner that the job will run on
     name: buildpushdev
-    runs-on: [self-hosted, linux]
+    runs-on: [ubuntu-latest]
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4

--- a/.github/workflows/buildpushtagged.yml
+++ b/.github/workflows/buildpushtagged.yml
@@ -8,7 +8,7 @@ jobs:
   build_test:
     # The type of runner that the job will run on
     name: buildpush
-    runs-on: [self-hosted, linux]
+    runs-on: [ubuntu-latest]
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   golangci:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     name: lint
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   tests:
-    runs-on: [self-hosted, linux]
+    runs-on: [ubuntu-latest]
 
     steps:
       - name: Install Go

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3098,6 +3098,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "deviceDefinitionId": {
+                    "description": "deprecated",
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3090,6 +3090,7 @@
                     "type": "string"
                 },
                 "deviceDefinitionId": {
+                    "description": "deprecated",
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -635,6 +635,7 @@ definitions:
         description: DefinitionID new slug id
         type: string
       deviceDefinitionId:
+        description: deprecated
         type: string
     type: object
   internal_controllers.RegisterUserDeviceResponse:

--- a/internal/controllers/device_data_controller_test.go
+++ b/internal/controllers/device_data_controller_test.go
@@ -107,7 +107,7 @@ func TestUserDevicesController_QueryDeviceErrorCodes(t *testing.T) {
 			ErrorCodes: []string{"P0017", "P0016"},
 		}
 
-		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+		autoPiInteg := test.BuildIntegrationGRPC(ksuid.New().String(), constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
 		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
@@ -187,7 +187,7 @@ func TestUserDevicesController_ShouldErrorOnTooManyErrorCodes(t *testing.T) {
 			ErrorCodes: erCodes,
 		}
 
-		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+		autoPiInteg := test.BuildIntegrationGRPC(ksuid.New().String(), constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
 		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
@@ -257,7 +257,7 @@ func TestUserDevicesController_ShouldErrorInvalidErrorCodes(t *testing.T) {
 			ErrorCodes: []string{"P0010:30", "P33333339"},
 		}
 
-		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+		autoPiInteg := test.BuildIntegrationGRPC(ksuid.New().String(), constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
 		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].Id, nil, "", pdb)
 
@@ -327,7 +327,7 @@ func TestUserDevicesController_ShouldErrorOnEmptyErrorCodes(t *testing.T) {
 			ErrorCodes: []string{},
 		}
 
-		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+		autoPiInteg := test.BuildIntegrationGRPC(ksuid.New().String(), constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
 		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].Id, nil, "", pdb)
 
@@ -397,7 +397,7 @@ func TestUserDevicesController_ShouldStoreErrorCodeResponse(t *testing.T) {
 			ErrorCodes: erCodeReq,
 		}
 
-		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+		autoPiInteg := test.BuildIntegrationGRPC(ksuid.New().String(), constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
 		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].Id, nil, "", pdb)
 
@@ -479,7 +479,7 @@ func TestUserDevicesController_GetUserDevicesErrorCodeQueries(t *testing.T) {
 
 	t.Run("GET - all saved error code response for current user devices", func(t *testing.T) {
 
-		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+		autoPiInteg := test.BuildIntegrationGRPC(ksuid.New().String(), constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
 		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
@@ -554,7 +554,7 @@ func TestUserDevicesController_ClearUserDeviceErrorCodeQuery(t *testing.T) {
 	app.Post("/user/devices/:userDeviceID/error-codes/clear", test.AuthInjectorTestHandler(testUserID), c.ClearUserDeviceErrorCodeQuery)
 
 	t.Run("POST - clear last saved error code response for current user devices", func(t *testing.T) {
-		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+		autoPiInteg := test.BuildIntegrationGRPC(ksuid.New().String(), constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
 		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 
@@ -641,7 +641,7 @@ func TestUserDevicesController_ErrorOnAllErrorCodesCleared(t *testing.T) {
 	app.Post("/user/devices/:userDeviceID/error-codes/clear", test.AuthInjectorTestHandler(testUserID), c.ClearUserDeviceErrorCodeQuery)
 
 	t.Run("POST - clear last saved error code response for current user devices", func(t *testing.T) {
-		autoPiInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+		autoPiInteg := test.BuildIntegrationGRPC(ksuid.New().String(), constants.AutoPiVendor, 10, 0)
 		dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Toyota", "Camry", 2023, autoPiInteg)
 		ud := test.SetupCreateUserDevice(t, testUserID, dd[0].DeviceDefinitionId, nil, "", pdb)
 

--- a/internal/controllers/geofences_controller.go
+++ b/internal/controllers/geofences_controller.go
@@ -275,7 +275,7 @@ func (g *GeofencesController) GetAll(c *fiber.Ctx) error {
 		for _, udtg := range item.R.UserDeviceToGeofences {
 			var deviceDef *ddgrpc.GetDeviceDefinitionItemResponse
 			for _, dd := range dds {
-				if dd.DeviceDefinitionId == udtg.R.UserDevice.DeviceDefinitionID {
+				if dd.Id == udtg.R.UserDevice.DefinitionID {
 					deviceDef = dd
 				}
 			}

--- a/internal/controllers/geofences_controller_test.go
+++ b/internal/controllers/geofences_controller_test.go
@@ -275,8 +275,8 @@ func (s *GeofencesControllerTestSuite) TestPutGeofence() {
 	app.Put("/user/geofences/:geofenceID", test.AuthInjectorTestHandler(injectedUserID), c.Update)
 
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "escaped", 2020, nil)
-	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), []string{dd[0].DeviceDefinitionId}).Return(dd, nil)
-	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
+	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), dd[0].Id).Return(dd[0], nil)
+	ud := test.SetupCreateUserDevice(s.T(), injectedUserID, dd[0].Id, nil, "", s.pdb)
 	ud.TokenID = types.NewNullDecimal(decimal.New(1, 0))
 	_, err := ud.Update(s.ctx, s.pdb.DBS().Writer, boil.Infer())
 	s.Require().NoError(err)

--- a/internal/controllers/user_devices_controller_test.go
+++ b/internal/controllers/user_devices_controller_test.go
@@ -149,7 +149,7 @@ func TestUserDevicesControllerTestSuite(t *testing.T) {
 /* Actual Tests */
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	vinny := "4T3R6RFVXMU023395"
@@ -208,7 +208,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar() {
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_Decode() {
 	// arrange DB
-	_ = test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	_ = test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	// act request
 	const vinny = "4T3R6RFVXMU023395"
 	reg := RegisterUserDeviceSmartcar{Code: "XX", RedirectURI: "https://mobile-app", CountryCode: "USA"}
@@ -239,7 +239,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_Dec
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_SameUser_DuplicateVIN() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 
 	// act request
@@ -272,7 +272,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_SameUser
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_DuplicateVIN() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 
 	// act request
@@ -303,7 +303,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_Dup
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	const deviceStyleID = "24GE7Mlc4c9o4j5P4mcD1Fzinx1"
@@ -319,7 +319,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN() {
 		Year:          dd[0].Year,
 	}, nil)
 
-	apInteg := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 10)
+	apInteg := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 10)
 	s.deviceDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Times(1).Return(apInteg, nil)
 	s.userDeviceSvc.EXPECT().CreateUserDevice(gomock.Any(), dd[0].Id, deviceStyleID, "USA", s.testUserID, &vinny, &canProtocol, false).Times(1).
 		Return(&models.UserDevice{
@@ -363,7 +363,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_FailDecode() {
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	_ = test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 
 	vinny := "4T3R6RFVXMU023395"
@@ -376,7 +376,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_FailDecode() 
 	s.deviceDefSvc.EXPECT().DecodeVIN(gomock.Any(), vinny, "", 0, reg.CountryCode).Times(1).
 		Return(nil, grpcErr)
 
-	apInteg := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 10)
+	apInteg := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 10)
 	s.deviceDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Times(1).Return(apInteg, nil)
 
 	request := test.BuildRequest("POST", "/user/devices/fromvin", string(j))
@@ -391,7 +391,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_FailDecode() 
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_SameUser_DuplicateVIN() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	const vinny = "4T3R6RFVXMU023395"
@@ -402,7 +402,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_SameUser_Dupl
 	// if the vin already exists for this user, do not expect decode request
 
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), dd[0].Id).Times(1).Return(dd[0], nil)
-	apInteg := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 10)
+	apInteg := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 10)
 	s.deviceDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Times(1).Return(apInteg, nil)
 
 	request := test.BuildRequest("POST", "/user/devices/fromvin", string(j))
@@ -436,7 +436,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_SameUser_Dupl
 
 func (s *UserDevicesControllerTestSuite) TestPostWithExistingDefinitionID() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	reg := RegisterUserDevice{
@@ -475,7 +475,7 @@ func (s *UserDevicesControllerTestSuite) TestPostWithExistingDefinitionID() {
 
 func (s *UserDevicesControllerTestSuite) TestPostWithExistingDeviceDefinitionID() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	reg := RegisterUserDevice{
@@ -575,7 +575,7 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevices() {
 		deviceID2 = "device2"
 	)
 
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].Id, nil, "", s.pdb)
 	_ = test.SetupCreateAftermarketDevice(s.T(), testUserID, nil, unitID, func(s string) *string { return &s }(deviceID), s.pdb)
@@ -619,7 +619,7 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevicesNoDuplicates() {
 	)
 	s.controller.Settings.Environment = "dev"
 
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	ud := test.SetupCreateUserDeviceWithDeviceID(s.T(), userID, deviceID, dd[0].Id, nil, "", s.pdb)
 	_ = test.SetupCreateAftermarketDevice(s.T(), userID, nil, unitID, func(s string) *string { return &s }(deviceID), s.pdb)
@@ -652,7 +652,7 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevicesNoDuplicates() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPatchVIN() {
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 4)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 4)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Escape", 2020, integration)
 
 	const powertrainType = "powertrain_type"
@@ -730,7 +730,7 @@ func (s *UserDevicesControllerTestSuite) TestVINValidate() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCar() {
-	smartCarInt := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
+	smartCarInt := test.BuildIntegrationGRPC(smartCarIntegrationID, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Escape", 2020, smartCarInt)
 	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	s.deviceDefSvc.EXPECT().GetIntegrationByVendor(gomock.Any(), constants.SmartCarVendor).Return(smartCarInt, nil)
@@ -780,7 +780,7 @@ func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCar() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCarRateLimited() {
-	integration := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(smartCarIntegrationID, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Mache", 2022, integration)
 	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	s.deviceDefSvc.EXPECT().GetIntegrationByVendor(gomock.Any(), constants.SmartCarVendor).Return(integration, nil)

--- a/internal/controllers/user_devices_controller_test.go
+++ b/internal/controllers/user_devices_controller_test.go
@@ -149,7 +149,7 @@ func TestUserDevicesControllerTestSuite(t *testing.T) {
 /* Actual Tests */
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	vinny := "4T3R6RFVXMU023395"
@@ -208,7 +208,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar() {
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_Decode() {
 	// arrange DB
-	_ = test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	_ = test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	// act request
 	const vinny = "4T3R6RFVXMU023395"
 	reg := RegisterUserDeviceSmartcar{Code: "XX", RedirectURI: "https://mobile-app", CountryCode: "USA"}
@@ -239,7 +239,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_Dec
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_SameUser_DuplicateVIN() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 
 	// act request
@@ -272,7 +272,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_SameUser
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_DuplicateVIN() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 
 	// act request
@@ -303,7 +303,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromSmartcar_Fail_Dup
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	const deviceStyleID = "24GE7Mlc4c9o4j5P4mcD1Fzinx1"
@@ -319,7 +319,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN() {
 		Year:          dd[0].Year,
 	}, nil)
 
-	apInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 10)
+	apInteg := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 10)
 	s.deviceDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Times(1).Return(apInteg, nil)
 	s.userDeviceSvc.EXPECT().CreateUserDevice(gomock.Any(), dd[0].Id, deviceStyleID, "USA", s.testUserID, &vinny, &canProtocol, false).Times(1).
 		Return(&models.UserDevice{
@@ -363,7 +363,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_FailDecode() {
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	_ = test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 
 	vinny := "4T3R6RFVXMU023395"
@@ -376,7 +376,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_FailDecode() 
 	s.deviceDefSvc.EXPECT().DecodeVIN(gomock.Any(), vinny, "", 0, reg.CountryCode).Times(1).
 		Return(nil, grpcErr)
 
-	apInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 10)
+	apInteg := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 10)
 	s.deviceDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Times(1).Return(apInteg, nil)
 
 	request := test.BuildRequest("POST", "/user/devices/fromvin", string(j))
@@ -391,7 +391,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_FailDecode() 
 
 func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_SameUser_DuplicateVIN() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	const vinny = "4T3R6RFVXMU023395"
@@ -402,7 +402,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_SameUser_Dupl
 	// if the vin already exists for this user, do not expect decode request
 
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), dd[0].Id).Times(1).Return(dd[0], nil)
-	apInteg := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 10)
+	apInteg := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 10)
 	s.deviceDefIntSvc.EXPECT().GetAutoPiIntegration(gomock.Any()).Times(1).Return(apInteg, nil)
 
 	request := test.BuildRequest("POST", "/user/devices/fromvin", string(j))
@@ -436,7 +436,7 @@ func (s *UserDevicesControllerTestSuite) TestPostUserDeviceFromVIN_SameUser_Dupl
 
 func (s *UserDevicesControllerTestSuite) TestPostWithExistingDefinitionID() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	reg := RegisterUserDevice{
@@ -475,7 +475,7 @@ func (s *UserDevicesControllerTestSuite) TestPostWithExistingDefinitionID() {
 
 func (s *UserDevicesControllerTestSuite) TestPostWithExistingDeviceDefinitionID() {
 	// arrange DB
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	// act request
 	reg := RegisterUserDevice{
@@ -575,7 +575,7 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevices() {
 		deviceID2 = "device2"
 	)
 
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].Id, nil, "", s.pdb)
 	_ = test.SetupCreateAftermarketDevice(s.T(), testUserID, nil, unitID, func(s string) *string { return &s }(deviceID), s.pdb)
@@ -619,7 +619,7 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevicesNoDuplicates() {
 	)
 	s.controller.Settings.Environment = "dev"
 
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	ud := test.SetupCreateUserDeviceWithDeviceID(s.T(), userID, deviceID, dd[0].Id, nil, "", s.pdb)
 	_ = test.SetupCreateAftermarketDevice(s.T(), userID, nil, unitID, func(s string) *string { return &s }(deviceID), s.pdb)
@@ -652,7 +652,7 @@ func (s *UserDevicesControllerTestSuite) TestGetMyUserDevicesNoDuplicates() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPatchVIN() {
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 4)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 4)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Escape", 2020, integration)
 
 	const powertrainType = "powertrain_type"
@@ -730,7 +730,7 @@ func (s *UserDevicesControllerTestSuite) TestVINValidate() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCar() {
-	smartCarInt := test.BuildIntegrationGRPC(constants.SmartCarVendor, 10, 0)
+	smartCarInt := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Escape", 2020, smartCarInt)
 	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	s.deviceDefSvc.EXPECT().GetIntegrationByVendor(gomock.Any(), constants.SmartCarVendor).Return(smartCarInt, nil)
@@ -780,7 +780,7 @@ func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCar() {
 }
 
 func (s *UserDevicesControllerTestSuite) TestPostRefreshSmartCarRateLimited() {
-	integration := test.BuildIntegrationGRPC(constants.SmartCarVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Mache", 2022, integration)
 	ud := test.SetupCreateUserDevice(s.T(), s.testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	s.deviceDefSvc.EXPECT().GetIntegrationByVendor(gomock.Any(), constants.SmartCarVendor).Return(integration, nil)

--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -1734,7 +1734,7 @@ func (udc *UserDevicesController) runPostRegistration(ctx context.Context, logge
 	err = udc.deviceDefinitionRegistrar.Register(services.DeviceDefinitionDTO{
 		IntegrationID:      integ.Id,
 		UserDeviceID:       ud.ID,
-		DeviceDefinitionID: ud.DeviceDefinitionID,
+		DeviceDefinitionID: ud.DeviceDefinitionID, // this needs to be changed - can we change it, what does the registrar do
 		Make:               dd.Make.Name,
 		Model:              dd.Model,
 		Year:               int(dd.Year),

--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -1723,28 +1723,6 @@ func (udc *UserDevicesController) runPostRegistration(ctx context.Context, logge
 	if err != nil {
 		logger.Err(err).Msg("Failed to emit integration event.")
 	}
-
-	region := ""
-	if ud.CountryCode.Valid {
-		countryRecord := constants.FindCountry(ud.CountryCode.String)
-		if countryRecord != nil {
-			region = countryRecord.Region
-		}
-	}
-	err = udc.deviceDefinitionRegistrar.Register(services.DeviceDefinitionDTO{
-		IntegrationID:      integ.Id,
-		UserDeviceID:       ud.ID,
-		DeviceDefinitionID: ud.DeviceDefinitionID, // this needs to be changed - can we change it, what does the registrar do
-		Make:               dd.Make.Name,
-		Model:              dd.Model,
-		Year:               int(dd.Year),
-		Region:             region,
-		MakeSlug:           dd.Make.NameSlug,
-		ModelSlug:          shared.SlugString(dd.Model),
-	})
-	if err != nil {
-		logger.Err(err).Msg("Failed to set values in device definition tables.")
-	}
 }
 
 var smartcarCallErr = fiber.NewError(fiber.StatusInternalServerError, "Error communicating with Smartcar.")

--- a/internal/controllers/user_integrations_controller_test.go
+++ b/internal/controllers/user_integrations_controller_test.go
@@ -87,7 +87,7 @@ const testUser2 = "someOtherUser2"
 const teslaFleetAuthCacheKey = "integration_credentials_%s"
 
 const smartCarIntegrationId = "smartcar123"
-const teslaIntegrationId = "tesla123"
+const teslaIntegrationId = "tesla123aaaaaaaaaaaaaaaaaaa"
 
 // SetupSuite starts container db
 func (s *UserIntegrationsControllerTestSuite) SetupSuite() {
@@ -387,7 +387,8 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessCachedToke
 	s.scClient.EXPECT().HasDoorControl(gomock.Any(), token.Access, "smartcar-idx").Return(false, nil)
 
 	// original device def
-	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DefinitionID).Times(2).Return(dd[0], nil)
+	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DefinitionID).Times(1).Return(dd[0], nil)
+	s.deviceDefSvc.EXPECT().GetIntegrationByID(gomock.Any(), integration.Id).Return(integration, nil)
 
 	request := test.BuildRequest("POST", "/user/devices/"+ud.ID+"/integrations/"+integration.Id, req)
 	response, err := s.app.Test(request)
@@ -413,6 +414,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostUnknownDevice() {
 	response, _ := s.app.Test(request)
 	assert.Equal(s.T(), fiber.StatusBadRequest, response.StatusCode, "should fail")
 }
+
 func (s *UserIntegrationsControllerTestSuite) TestPostTesla() {
 	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model Y", 2020, integration)
@@ -444,8 +446,9 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla() {
 	}, nil)
 	s.teslaSvc.EXPECT().WakeUpVehicle("abc", 1145).Return(nil)
 	s.teslaSvc.EXPECT().GetAvailableCommands().Return(&services.UserDeviceAPIIntegrationsMetadataCommands{Enabled: []string{constants.DoorsUnlock, constants.DoorsLock}})
-	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DefinitionID).Times(2).Return(dd[0], nil)
+	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DefinitionID).Times(1).Return(dd[0], nil)
 	s.deviceDefSvc.EXPECT().FindDeviceDefinitionByMMY(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dd[0], nil)
+	s.deviceDefSvc.EXPECT().GetIntegrationByID(gomock.Any(), integration.Id).Return(integration, nil)
 
 	req := `{
 			"accessToken": "abc",
@@ -791,8 +794,9 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2() {
 		Enabled:  []string{constants.DoorsUnlock, constants.DoorsLock, constants.TrunkOpen, constants.FrunkOpen, constants.ChargeLimit},
 		Disabled: []string{constants.TelemetrySubscribe},
 	}, nil)
-	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DeviceDefinitionID).Times(2).Return(dd[0], nil)
+	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DefinitionID).Times(1).Return(dd[0], nil)
 	s.deviceDefSvc.EXPECT().FindDeviceDefinitionByMMY(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(dd[0], nil)
+	s.deviceDefSvc.EXPECT().GetIntegrationByID(gomock.Any(), integration.Id).Times(1).Return(integration, nil)
 
 	userEthAddr := common.HexToAddress("1").String()
 	s.userClient.EXPECT().GetUser(gomock.Any(), &pbuser.GetUserRequest{Id: testUserID}).Return(&pbuser.User{EthereumAddress: &userEthAddr}, nil).AnyTimes()
@@ -848,7 +852,8 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2_PartialCredential
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model Y", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
-	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DeviceDefinitionID).Return(dd[0], nil).AnyTimes()
+	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DefinitionID).Return(dd[0], nil).AnyTimes()
+	s.deviceDefSvc.EXPECT().GetIntegrationByID(gomock.Any(), integration.Id).Return(integration, nil).AnyTimes()
 
 	userEthAddr := common.HexToAddress("1").String()
 	s.userClient.EXPECT().GetUser(gomock.Any(), &pbuser.GetUserRequest{Id: testUserID}).Return(&pbuser.User{EthereumAddress: &userEthAddr}, nil).AnyTimes()
@@ -884,7 +889,8 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2_MissingCredential
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model Y", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
-	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DeviceDefinitionID).Return(dd[0], nil).AnyTimes()
+	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DefinitionID).Return(dd[0], nil).AnyTimes()
+	s.deviceDefSvc.EXPECT().GetIntegrationByID(gomock.Any(), integration.Id).Return(integration, nil).AnyTimes()
 
 	userEthAddr := common.HexToAddress("1").String()
 	s.userClient.EXPECT().GetUser(gomock.Any(), &pbuser.GetUserRequest{Id: testUserID}).Return(&pbuser.User{EthereumAddress: &userEthAddr}, nil).AnyTimes()

--- a/internal/controllers/user_integrations_controller_test.go
+++ b/internal/controllers/user_integrations_controller_test.go
@@ -260,17 +260,6 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessNewToken()
 		},
 	)
 
-	s.deviceDefinitionRegistrar.EXPECT().Register(services.DeviceDefinitionDTO{
-		IntegrationID: integration.Id,
-		UserDeviceID:  ud.ID,
-		Make:          dd[0].Make.Name,
-		Model:         dd[0].Model,
-		Year:          int(dd[0].Year),
-		Region:        "Americas",
-		MakeSlug:      dd[0].Make.NameSlug,
-		ModelSlug:     shared.SlugString(dd[0].Model),
-	}).Return(nil)
-
 	// original device def
 	s.deviceDefSvc.EXPECT().GetDeviceDefinitionBySlug(gomock.Any(), ud.DefinitionID).Times(2).Return(dd[0], nil)
 	s.scClient.EXPECT().GetUserID(gomock.Any(), "myAccess").Return(smartCarUserID, nil)
@@ -392,18 +381,6 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessCachedToke
 		},
 	)
 
-	s.deviceDefinitionRegistrar.EXPECT().Register(services.DeviceDefinitionDTO{
-		IntegrationID:      integration.Id,
-		UserDeviceID:       ud.ID,
-		DeviceDefinitionID: ud.DeviceDefinitionID,
-		Make:               dd[0].Make.Name,
-		Model:              dd[0].Model,
-		Year:               int(dd[0].Year),
-		Region:             "Americas",
-		MakeSlug:           dd[0].Make.NameSlug,
-		ModelSlug:          shared.SlugString(dd[0].Model),
-	}).Return(nil)
-
 	s.scClient.EXPECT().GetUserID(gomock.Any(), token.Access).Return(smartCarUserID, nil)
 	s.scClient.EXPECT().GetExternalID(gomock.Any(), token.Access).Return("smartcar-idx", nil)
 	s.scClient.EXPECT().GetEndpoints(gomock.Any(), token.Access, "smartcar-idx").Return([]string{"/", "/vin"}, nil)
@@ -459,18 +436,6 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla() {
 			return nil
 		},
 	)
-
-	s.deviceDefinitionRegistrar.EXPECT().Register(services.DeviceDefinitionDTO{
-		IntegrationID:      integration.Id,
-		UserDeviceID:       ud.ID,
-		DeviceDefinitionID: ud.DeviceDefinitionID,
-		Make:               dd[0].Make.Name,
-		Model:              dd[0].Model,
-		Year:               int(dd[0].Year),
-		Region:             "Americas",
-		MakeSlug:           dd[0].Make.NameSlug,
-		ModelSlug:          shared.SlugString(dd[0].Model),
-	}).Return(nil)
 
 	s.teslaSvc.EXPECT().GetVehicle("abc", 1145).Return(&services.TeslaVehicle{
 		ID:        1145,
@@ -815,18 +780,6 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2() {
 			return nil
 		},
 	)
-
-	s.deviceDefinitionRegistrar.EXPECT().Register(services.DeviceDefinitionDTO{
-		IntegrationID:      integration.Id,
-		UserDeviceID:       ud.ID,
-		DeviceDefinitionID: ud.DeviceDefinitionID,
-		Make:               dd[0].Make.Name,
-		Model:              dd[0].Model,
-		Year:               int(dd[0].Year),
-		Region:             "Americas",
-		MakeSlug:           dd[0].Make.NameSlug,
-		ModelSlug:          shared.SlugString(dd[0].Model),
-	}).Return(nil)
 
 	s.teslaFleetAPISvc.EXPECT().GetVehicle(gomock.Any(), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", 1145).Return(&services.TeslaVehicle{
 		ID:        1145,

--- a/internal/controllers/user_integrations_controller_test.go
+++ b/internal/controllers/user_integrations_controller_test.go
@@ -86,8 +86,12 @@ const testUser2 = "someOtherUser2"
 // TODO(elffjs): This shouldn't be necessary anymore. Need to work with an interface.
 const teslaFleetAuthCacheKey = "integration_credentials_%s"
 
-const smartCarIntegrationId = "smartcar123"
-const teslaIntegrationId = "tesla123aaaaaaaaaaaaaaaaaaa"
+// integration ID's - must be 27 chars to match ksuid length
+const (
+	smartCarIntegrationID = "smartcar123aaaaaaaaaaaaaaaa"
+	teslaIntegrationID    = "tesla123aaaaaaaaaaaaaaaaaaa"
+	autoPiIntegrationID   = "autopi123aaaaaaaaaaaaaaaaaa"
+)
 
 // SetupSuite starts container db
 func (s *UserIntegrationsControllerTestSuite) SetupSuite() {
@@ -161,7 +165,7 @@ func TestUserIntegrationsControllerTestSuite(t *testing.T) {
 /* Actual Tests */
 
 func (s *UserIntegrationsControllerTestSuite) TestPostSmartCarFailure() {
-	integration := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(smartCarIntegrationID, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Mach E", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
@@ -186,7 +190,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCarFailure() {
 
 func (s *UserIntegrationsControllerTestSuite) TestDeleteIntegration_BlockedBySyntheticDevice() {
 	model := "Mach E"
-	integration := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(smartCarIntegrationID, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", model, 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 	vnft := test.SetupCreateVehicleNFT(s.T(), ud, big.NewInt(5), null.BytesFrom(common.HexToAddress("0xA1").Bytes()), s.pdb)
@@ -222,7 +226,7 @@ func (s *UserIntegrationsControllerTestSuite) TestDeleteIntegration_BlockedBySyn
 func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessNewToken() {
 	model := "Mach E"
 	const vin = "CARVIN"
-	integration := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(smartCarIntegrationID, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", model, 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
@@ -290,7 +294,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessNewToken()
 func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_FailureTestVIN() {
 	model := "Mach E"
 	const vin = "0SC12312312312312"
-	integration := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(smartCarIntegrationID, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", model, 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
@@ -332,7 +336,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_FailureTestVIN() 
 func (s *UserIntegrationsControllerTestSuite) TestPostSmartCar_SuccessCachedToken() {
 	model := "Mach E"
 	const vin = "CARVIN"
-	integration := test.BuildIntegrationGRPC(smartCarIntegrationId, constants.SmartCarVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(smartCarIntegrationID, constants.SmartCarVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", model, 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 	ud.VinIdentifier = null.StringFrom(vin)
@@ -416,7 +420,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostUnknownDevice() {
 }
 
 func (s *UserIntegrationsControllerTestSuite) TestPostTesla() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model Y", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
@@ -484,7 +488,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla() {
 }
 
 func (s *UserIntegrationsControllerTestSuite) TestPostTeslaAndUpdateDD() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 20)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 20)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "Mach E", 2020, integration)
 
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
@@ -761,7 +765,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPairAftermarketNoLegacy() {
 
 // Tesla Fleet API Tests
 func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model Y", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
@@ -848,7 +852,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2() {
 }
 
 func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2_PartialCredentials() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model Y", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
@@ -885,7 +889,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2_PartialCredential
 }
 
 func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2_MissingCredentials() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model Y", 2020, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "", s.pdb)
 
@@ -912,7 +916,7 @@ func (s *UserIntegrationsControllerTestSuite) TestPostTesla_V2_MissingCredential
 }
 
 func (s *UserIntegrationsControllerTestSuite) TestGetUserDeviceIntegration() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model S", 2012, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "5YJSA1CN0CFP02439", s.pdb)
 
@@ -963,7 +967,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetUserDeviceIntegration() {
 }
 
 func (s *UserIntegrationsControllerTestSuite) TestTelemetrySubscribe() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model S", 2012, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "5YJSA1CN0CFP02439", s.pdb)
 
@@ -1025,7 +1029,7 @@ func (s *UserIntegrationsControllerTestSuite) Test_NoUserDevice_TelemetrySubscri
 }
 
 func (s *UserIntegrationsControllerTestSuite) Test_InactiveIntegration_TelemetrySubscribe() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model S", 2012, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "5YJSA1CN0CFP02439", s.pdb)
 
@@ -1045,7 +1049,7 @@ func (s *UserIntegrationsControllerTestSuite) Test_InactiveIntegration_Telemetry
 }
 
 func (s *UserIntegrationsControllerTestSuite) Test_MissingRegionAndCapable_TelemetrySubscribe() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model S", 2012, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "5YJSA1CN0CFP02439", s.pdb)
 
@@ -1065,7 +1069,7 @@ func (s *UserIntegrationsControllerTestSuite) Test_MissingRegionAndCapable_Telem
 }
 
 func (s *UserIntegrationsControllerTestSuite) Test_TelemetrySubscribe_NotCapable() {
-	integration := test.BuildIntegrationGRPC(teslaIntegrationId, constants.TeslaVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(teslaIntegrationID, constants.TeslaVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model S", 2012, integration)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].Id, nil, "5YJSA1CN0CFP02439", s.pdb)
 

--- a/internal/controllers/webhooks_controller_test.go
+++ b/internal/controllers/webhooks_controller_test.go
@@ -115,7 +115,7 @@ func (s *WebHooksControllerTestSuite) TestPostWebhookSyncCommand() {
 	autoPiDeviceID := "123123"
 	autoPiTemplateID := 987
 	autoPiJobID := "AD111"
-	integ := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, autoPiTemplateID, 0)
+	integ := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, autoPiTemplateID, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model X", 2020, integ)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	autopiJob := test.SetupCreateAutoPiJob(s.T(), autoPiJobID, autoPiDeviceID, "state.sls pending", ud.ID, "COMMAND_EXECUTED", "", s.pdb)
@@ -184,7 +184,7 @@ func (s *WebHooksControllerTestSuite) TestPostWebhookRawCommand() {
 	autoPiDeviceID := "123123"
 	autoPiTemplateID := 987
 	autoPiJobID := "AD111"
-	integ := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, autoPiTemplateID, 0)
+	integ := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, autoPiTemplateID, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model X", 2020, integ)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	// create user device api integration

--- a/internal/controllers/webhooks_controller_test.go
+++ b/internal/controllers/webhooks_controller_test.go
@@ -115,7 +115,7 @@ func (s *WebHooksControllerTestSuite) TestPostWebhookSyncCommand() {
 	autoPiDeviceID := "123123"
 	autoPiTemplateID := 987
 	autoPiJobID := "AD111"
-	integ := test.BuildIntegrationGRPC(constants.AutoPiVendor, autoPiTemplateID, 0)
+	integ := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, autoPiTemplateID, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Tesla", "Model X", 2020, integ)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	autopiJob := test.SetupCreateAutoPiJob(s.T(), autoPiJobID, autoPiDeviceID, "state.sls pending", ud.ID, "COMMAND_EXECUTED", "", s.pdb)
@@ -184,7 +184,7 @@ func (s *WebHooksControllerTestSuite) TestPostWebhookRawCommand() {
 	autoPiDeviceID := "123123"
 	autoPiTemplateID := 987
 	autoPiJobID := "AD111"
-	integ := test.BuildIntegrationGRPC(constants.AutoPiVendor, autoPiTemplateID, 0)
+	integ := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, autoPiTemplateID, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Testla", "Model X", 2020, integ)
 	ud := test.SetupCreateUserDevice(s.T(), testUserID, dd[0].DeviceDefinitionId, nil, "", s.pdb)
 	// create user device api integration

--- a/internal/rpc/user_devices_test.go
+++ b/internal/rpc/user_devices_test.go
@@ -26,9 +26,10 @@ import (
 )
 
 const migrationsDirRelPath = "../../migrations"
+const autoPiIntegrationID = "autopi123aaaaaaaaaaaaaaaaaa"
 
 func populateDB(ctx context.Context, pdb db.Store) (string, error) {
-	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC(autoPiIntegrationID, constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	vin := "W1N2539531F907299"
 	deviceStyleID := "24GE7Mlc4c9o4j5P4mcD1Fzinx1"

--- a/internal/rpc/user_devices_test.go
+++ b/internal/rpc/user_devices_test.go
@@ -28,7 +28,7 @@ import (
 const migrationsDirRelPath = "../../migrations"
 
 func populateDB(ctx context.Context, pdb db.Store) (string, error) {
-	integration := test.BuildIntegrationGRPC(constants.AutoPiVendor, 10, 0)
+	integration := test.BuildIntegrationGRPC("autopi123", constants.AutoPiVendor, 10, 0)
 	dd := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)
 	vin := "W1N2539531F907299"
 	deviceStyleID := "24GE7Mlc4c9o4j5P4mcD1Fzinx1"

--- a/internal/services/autopi/hardware_template_service_test.go
+++ b/internal/services/autopi/hardware_template_service_test.go
@@ -79,8 +79,8 @@ func (s *HardwareTemplateServiceTestSuite) Test_GetTemplateID() {
 	)
 	def, _ := strconv.Atoi(tIDIntegrationDefault)
 	bev, _ := strconv.Atoi(tIDBEVPowertrainUD)
-	integration := test.BuildIntegrationDefaultGRPC(constants.AutoPiVendor, def, bev, true)
-	integrationWithoutAutoPiPowertrainTemplate := test.BuildIntegrationDefaultGRPC(constants.AutoPiVendor, def, 0, false)
+	integration := test.BuildIntegrationDefaultGRPC(ksuid.New().String(), constants.AutoPiVendor, def, bev, true)
+	integrationWithoutAutoPiPowertrainTemplate := test.BuildIntegrationDefaultGRPC(ksuid.New().String(), constants.AutoPiVendor, def, 0, false)
 
 	ddWithTID := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)[0]
 	ddWithDeviceStyleTID := test.BuildDeviceDefinitionGRPC(ksuid.New().String(), "Ford", "F150", 2020, integration)[0]

--- a/internal/services/device_definition_registrar.go
+++ b/internal/services/device_definition_registrar.go
@@ -13,7 +13,8 @@ import (
 
 //go:generate mockgen -source device_definition_registrar.go -destination mocks/device_definition_registrar_mock.go
 
-// DeviceDefinitionRegistrar
+// DeviceDefinitionRegistrar is used to send user device to MMY mappings to a kafka topic that is joined by device-definition-join-processor.
+// It was used to add MMY to elastic status index. Not really used anymore, should deprecate as possible.
 type DeviceDefinitionRegistrar interface {
 	Register(d DeviceDefinitionDTO) error
 }
@@ -116,6 +117,7 @@ func (s *deviceDefinitionRegistrar) emitKafka(topic, key string, value any) erro
 	return err
 }
 
+// Deprecated: Register processes a DeviceDefinitionDTO, emitting relevant events to the configured Kafka topics.
 func (s *deviceDefinitionRegistrar) Register(d DeviceDefinitionDTO) error {
 	err := s.emitDeviceDefinitionIDEvent(d)
 	if err != nil {

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -412,12 +412,12 @@ func SetupCreateGeofence(t *testing.T, userID, name string, ud *models.UserDevic
 }
 
 // BuildIntegrationDefaultGRPC depending on integration vendor, defines an integration object with typical settings. Smartcar refresh limit default is 100 seconds.
-func BuildIntegrationDefaultGRPC(integrationVendor string, autoPiDefaultTemplateID int, bevTemplateID int, includeAutoPiPowertrainTemplate bool) *ddgrpc.Integration {
+func BuildIntegrationDefaultGRPC(id, integrationVendor string, autoPiDefaultTemplateID int, bevTemplateID int, includeAutoPiPowertrainTemplate bool) *ddgrpc.Integration {
 	var integration *ddgrpc.Integration
 	switch integrationVendor {
 	case constants.AutoPiVendor:
 		integration = &ddgrpc.Integration{
-			Id:                      ksuid.New().String(),
+			Id:                      id,
 			Type:                    constants.IntegrationTypeHardware,
 			Style:                   constants.IntegrationStyleAddon,
 			Vendor:                  constants.AutoPiVendor,
@@ -434,7 +434,7 @@ func BuildIntegrationDefaultGRPC(integrationVendor string, autoPiDefaultTemplate
 		}
 	case constants.SmartCarVendor:
 		integration = &ddgrpc.Integration{
-			Id:               ksuid.New().String(),
+			Id:               id,
 			Type:             constants.IntegrationTypeAPI,
 			Style:            constants.IntegrationStyleWebhook,
 			Vendor:           constants.SmartCarVendor,
@@ -443,7 +443,7 @@ func BuildIntegrationDefaultGRPC(integrationVendor string, autoPiDefaultTemplate
 		}
 	case constants.TeslaVendor:
 		integration = &ddgrpc.Integration{
-			Id:      ksuid.New().String(),
+			Id:      id,
 			Type:    constants.IntegrationTypeAPI,
 			Style:   constants.IntegrationStyleOEM,
 			Vendor:  constants.TeslaVendor,
@@ -454,8 +454,8 @@ func BuildIntegrationDefaultGRPC(integrationVendor string, autoPiDefaultTemplate
 }
 
 // BuildIntegrationGRPC depending on integration vendor, defines an integration object with typical settings. Smartcar refresh limit default is 100 seconds.
-func BuildIntegrationGRPC(integrationVendor string, autoPiDefaultTemplateID int, bevTemplateID int) *ddgrpc.Integration {
-	return BuildIntegrationDefaultGRPC(integrationVendor, autoPiDefaultTemplateID, bevTemplateID, false)
+func BuildIntegrationGRPC(id, integrationVendor string, autoPiDefaultTemplateID int, bevTemplateID int) *ddgrpc.Integration {
+	return BuildIntegrationDefaultGRPC(id, integrationVendor, autoPiDefaultTemplateID, bevTemplateID, false)
 }
 
 // BuildDeviceDefinitionGRPC generates an array with single device definition, adds integration to response if integration passed in not nil. uses Americas region


### PR DESCRIPTION
Trying to fix CI

This also removes a call the the device definitions registrar that sent a message to a kafka topic for the device-definition-join-processor to use