### PR TITLE
EX-3182 Make required Tesla scopes a setting

### DIFF
--- a/charts/devices-api/values-prod.yaml
+++ b/charts/devices-api/values-prod.yaml
@@ -78,6 +78,7 @@ env:
     -----END CERTIFICATE-----
   VEHICLE_DECODING_GRPC_ADDR: vehicle-signal-decoding-prod:8086
   DEVICE_DEFINITIONS_GET_BY_KSUID_ENDPOINT: https://device-definitions-api.dimo.zone/device-definitions/
+  TESLA_REQUIRED_SCOPES: vehicle_device_data
 ingress:
   enabled: true
   className: nginx

--- a/charts/devices-api/values.yaml
+++ b/charts/devices-api/values.yaml
@@ -125,6 +125,7 @@ env:
   CLICKHOUSE_TCP_PORT: 9440
   CLICKHOUSE_DATABASE: dimo
   DEVICE_DEFINITIONS_GET_BY_KSUID_ENDPOINT: https://device-definitions-api.dev.dimo.zone/device-definitions/
+  TESLA_REQUIRED_SCOPES: vehicle_device_data,vehicle_location
 service:
   type: ClusterIP
   ports:

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -104,6 +104,8 @@ type Settings struct {
 	Clickhouse config.Settings `yaml:",inline"`
 
 	DeviceDefinitionsGetByKSUIDEndpoint string `yaml:"DEVICE_DEFINITIONS_GET_BY_KSUID_ENDPOINT"`
+
+	TeslaRequiredScopes string `json:"TESLA_REQUIRED_SCOPES"`
 }
 
 func (s *Settings) IsProduction() bool {

--- a/internal/controllers/user_integrations_auth_controller.go
+++ b/internal/controllers/user_integrations_auth_controller.go
@@ -101,8 +101,6 @@ type partialTeslaClaims struct {
 	OUCode string `json:"ou_code"`
 }
 
-var teslaDataScope = "vehicle_device_data"
-
 var teslaCodeFailureCount = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: "devices_api",

--- a/internal/controllers/user_integrations_auth_controller_test.go
+++ b/internal/controllers/user_integrations_auth_controller_test.go
@@ -52,8 +52,9 @@ func (s *UserIntegrationAuthControllerTestSuite) SetupSuite() {
 	s.teslaFleetAPISvc = mock_services.NewMockTeslaFleetAPIService(mockCtrl)
 	s.testUserID = "123123"
 	c := NewUserIntegrationAuthController(&config.Settings{
-		Port:        "3000",
-		Environment: "prod",
+		Port:                "3000",
+		Environment:         "prod",
+		TeslaRequiredScopes: "vehicle_device_data",
 	}, s.pdb.DBS, logger, s.deviceDefSvc, s.teslaFleetAPISvc, s.credStore)
 	app := test.SetupAppFiber(*logger)
 	s.userAddr = common.HexToAddress("1")


### PR DESCRIPTION
We previously hard-coded our demand for the Tesla `vehicle_device_data` scope, which gave us the telemetry data in which we were interested. [They announced on November 26](https://developer.tesla.com/docs/fleet-api/announcements#2024-11-26-introducing-a-new-oauth-scope-vehicle-location) that we now need `vehicle_location` to get latitude and longitude.

@adityap92 wants to test this out in the development environment, so here we make the required scopes a setting, `TESLA_REQUIRED_SCOPES`.