### PR TITLE
Smartcar onboarding try single call

### DIFF
--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -1035,6 +1035,8 @@ func (udc *UserDevicesController) RegisterDeviceForUserFromSmartcar(c *fiber.Ctx
 	if err != nil {
 		return err
 	}
+	// emit the event (also in register integration func), shouldn't get called again by other func since that one returns if finds existing udai record
+	udc.runPostRegistration(c.Context(), &localLog, udFull.ID, smartCarIntegrationID, integration)
 
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
 		"userDevice": udFull,


### PR DESCRIPTION
# Proposed Changes
- /fromsmartcar endpoint does all the work
- no need to call register integration endpoint
- tests have not been updated
- tried to do it without modifying much code

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->