### PR TITLE
when unpair device with newer endpoint, also mark autopi as unpaired

### DIFF
--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -1328,7 +1328,7 @@ func (udc *UserDevicesController) DeleteUserDevice(c *fiber.Ctx) error {
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
-// markAutoPiUnpaired tells the AP cloud this device has been marked as unpaired in their metadata, only if id is not empty
+// markAutoPiUnpaired tells the AP cloud this device has been marked as unpaired in their metadata, only if id is not empty. Also stops invoicing.
 func (udc *UserDevicesController) markAutoPiUnpaired(autopiDeviceID string) {
 	// autopi would like it if we updated the state to unpaired for these cases
 	if autopiDeviceID != "" {


### PR DESCRIPTION
# Proposed Changes
- another code flow where autopi's could get marked as unpaired, this stops billing from their end too.

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->