### PR TITLE
Use VIN instead of Tesla numeric id when checking Telemetry status

### DIFF
--- a/internal/controllers/user_integrations_controller.go
+++ b/internal/controllers/user_integrations_controller.go
@@ -133,7 +133,7 @@ func (udc *UserDevicesController) GetUserDeviceIntegration(c *fiber.Ctx) error {
 		}
 	}
 
-	telemStatus, err := udc.getTelemetrySubscriptionStatus(c.Context(), accessToken, apiIntegration.ExternalID.String)
+	telemStatus, err := udc.teslaFleetAPISvc.GetTelemetrySubscriptionStatus(c.Context(), accessToken, apiIntegration.R.UserDevice.VinIdentifier.String)
 	if err != nil {
 		logger.Err(err).Msg("Error checking Fleet Telemetry configuration.")
 		if errors.Is(err, services.ErrUnauthorized) {
@@ -203,15 +203,6 @@ func IsFirmwareFleetTelemetryCapable(v string) (bool, error) {
 	}
 
 	return year > 2024 || year == 2024 && week >= 26, nil
-}
-
-func (udc *UserDevicesController) getTelemetrySubscriptionStatus(ctx context.Context, accessToken, id string) (*services.VehicleTelemetryStatus, error) {
-	teslaID, err := strconv.Atoi(id)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't parse Tesla id as a number: %w", err)
-	}
-
-	return udc.teslaFleetAPISvc.GetTelemetrySubscriptionStatus(ctx, accessToken, teslaID)
 }
 
 func (udc *UserDevicesController) deleteDeviceIntegration(ctx context.Context, userID, userDeviceID, integrationID string, dd *ddgrpc.GetDeviceDefinitionItemResponse, tx *sql.Tx) error {

--- a/internal/controllers/user_integrations_controller_test.go
+++ b/internal/controllers/user_integrations_controller_test.go
@@ -788,7 +788,7 @@ func (s *UserIntegrationsControllerTestSuite) TestGetUserDeviceIntegration() {
 	s.Require().NoError(err)
 
 	s.deviceDefSvc.EXPECT().GetIntegrationByID(gomock.Any(), integration.Id).Return(integration, nil)
-	s.teslaFleetAPISvc.EXPECT().GetTelemetrySubscriptionStatus(gomock.Any(), accessTk, extID).Return(&services.VehicleTelemetryStatus{}, nil)
+	s.teslaFleetAPISvc.EXPECT().GetTelemetrySubscriptionStatus(gomock.Any(), accessTk, vin).Return(&services.VehicleTelemetryStatus{}, nil)
 
 	s.teslaFleetAPISvc.EXPECT().VirtualKeyConnectionStatus(gomock.Any(), accessTk, vin).Return(&services.VehicleFleetStatus{DiscountedDeviceData: true}, nil)
 

--- a/internal/services/mocks/tesla_fleet_api_service_mock.go
+++ b/internal/services/mocks/tesla_fleet_api_service_mock.go
@@ -72,18 +72,18 @@ func (mr *MockTeslaFleetAPIServiceMockRecorder) GetAvailableCommands(token any) 
 }
 
 // GetTelemetrySubscriptionStatus mocks base method.
-func (m *MockTeslaFleetAPIService) GetTelemetrySubscriptionStatus(ctx context.Context, token string, tokenID int) (*services.VehicleTelemetryStatus, error) {
+func (m *MockTeslaFleetAPIService) GetTelemetrySubscriptionStatus(ctx context.Context, token, vin string) (*services.VehicleTelemetryStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTelemetrySubscriptionStatus", ctx, token, tokenID)
+	ret := m.ctrl.Call(m, "GetTelemetrySubscriptionStatus", ctx, token, vin)
 	ret0, _ := ret[0].(*services.VehicleTelemetryStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTelemetrySubscriptionStatus indicates an expected call of GetTelemetrySubscriptionStatus.
-func (mr *MockTeslaFleetAPIServiceMockRecorder) GetTelemetrySubscriptionStatus(ctx, token, tokenID any) *gomock.Call {
+func (mr *MockTeslaFleetAPIServiceMockRecorder) GetTelemetrySubscriptionStatus(ctx, token, vin any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetrySubscriptionStatus", reflect.TypeOf((*MockTeslaFleetAPIService)(nil).GetTelemetrySubscriptionStatus), ctx, token, tokenID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetrySubscriptionStatus", reflect.TypeOf((*MockTeslaFleetAPIService)(nil).GetTelemetrySubscriptionStatus), ctx, token, vin)
 }
 
 // GetVehicle mocks base method.

--- a/internal/services/tesla_fleet_api_service.go
+++ b/internal/services/tesla_fleet_api_service.go
@@ -37,7 +37,7 @@ type TeslaFleetAPIService interface {
 	GetAvailableCommands(token string) (*UserDeviceAPIIntegrationsMetadataCommands, error)
 	VirtualKeyConnectionStatus(ctx context.Context, token, vin string) (*VehicleFleetStatus, error)
 	SubscribeForTelemetryData(ctx context.Context, token, vin string) error
-	GetTelemetrySubscriptionStatus(ctx context.Context, token string, tokenID int) (*VehicleTelemetryStatus, error)
+	GetTelemetrySubscriptionStatus(ctx context.Context, token, vin string) (*VehicleTelemetryStatus, error)
 }
 
 var teslaScopes = []string{"openid", "offline_access", "user_data", "vehicle_device_data", "vehicle_cmds", "vehicle_charging_cmds"}
@@ -449,8 +449,8 @@ func (t *teslaFleetAPIService) SubscribeForTelemetryData(ctx context.Context, to
 	return nil
 }
 
-func (t *teslaFleetAPIService) GetTelemetrySubscriptionStatus(ctx context.Context, token string, vehicleID int) (*VehicleTelemetryStatus, error) {
-	u := t.FleetBase.JoinPath("api/1/vehicles", strconv.Itoa(vehicleID), "fleet_telemetry_config")
+func (t *teslaFleetAPIService) GetTelemetrySubscriptionStatus(ctx context.Context, token, vin string) (*VehicleTelemetryStatus, error) {
+	u := t.FleetBase.JoinPath("api/1/vehicles", vin, "fleet_telemetry_config")
 
 	body, err := t.performRequest(ctx, u, token, http.MethodGet, nil)
 	if err != nil {


### PR DESCRIPTION
The key_paired field is simply wrong when you use id

# Proposed Changes

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->