### PR TITLE
Decode Tesla VINs with DD-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DIMO-Network/devices-api
 go 1.24.0
 
 require (
-	github.com/DIMO-Network/device-definitions-api v1.2.66
+	github.com/DIMO-Network/device-definitions-api v1.2.94
 	github.com/DIMO-Network/meta-transaction-processor v0.3.2
 	github.com/DIMO-Network/shared v0.12.9
 	github.com/DIMO-Network/synthetic-wallet-instance v0.0.0-20230601233541-6a4c8afb27d3

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1M
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DIMO-Network/clickhouse-infra v0.0.3 h1:B6/4IY9IxLcyydET14IjHUT+A5SDEis7p//DoFzrMk4=
 github.com/DIMO-Network/clickhouse-infra v0.0.3/go.mod h1:NtpQ1btkPzebDvpYYygeqiiBmJ/q5oJb/T/JWzUVRlk=
-github.com/DIMO-Network/device-definitions-api v1.2.66 h1:WRKZ+4CPH3+8QzVPG/Cl7DUcZ2p4AjDFHNxRqc9Kjzk=
-github.com/DIMO-Network/device-definitions-api v1.2.66/go.mod h1:0br3QBs+fNH1WtC/VMTYk0ekwebCnRk5OrXivo96NwA=
+github.com/DIMO-Network/device-definitions-api v1.2.94 h1:YKuk2U5Gu/LqXR+VzUmvPdHlIAm4W6V5iuwnIdUDx84=
+github.com/DIMO-Network/device-definitions-api v1.2.94/go.mod h1:18CMNHMMZ5i/7sb34rv8BxoDK6QWOOQ7apzc7X90/XY=
 github.com/DIMO-Network/meta-transaction-processor v0.3.2 h1:eSf34mSmiRilMbQx+4Iyu6aNm/WWJjbopIGYNjz/Z6w=
 github.com/DIMO-Network/meta-transaction-processor v0.3.2/go.mod h1:qJW4pNqQ4kDeumuZJByjrfrCd8dlrCT3//5V4PVKRqA=
 github.com/DIMO-Network/shared v0.12.9 h1:I41R/d84WedhQERdT7Iu7Bq8OnmLLQormfQb9g+vl1M=

--- a/internal/controllers/user_integrations_auth_controller.go
+++ b/internal/controllers/user_integrations_auth_controller.go
@@ -252,6 +252,6 @@ func (u *UserIntegrationAuthController) decodeTeslaVIN(ctx context.Context, vin 
 
 	teslaMake := "Tesla"
 	model := shared.VIN(vin).TeslaModel()
-	// decode vin doesn't return Model, just the ID
+	// key thing that matters here is the ID, this is a reduce payload compared to the full DD payload
 	return &decodeResult{ID: decodeVIN.DefinitionId, Make: teslaMake, Model: model, Year: int(decodeVIN.Year)}, nil
 }

--- a/internal/controllers/user_integrations_auth_controller.go
+++ b/internal/controllers/user_integrations_auth_controller.go
@@ -244,14 +244,14 @@ type decodeResult struct {
 }
 
 func (u *UserIntegrationAuthController) decodeTeslaVIN(ctx context.Context, vin string) (*decodeResult, error) {
-	teslaMake := "Tesla"
-	model := shared.VIN(vin).TeslaModel()
-	year := shared.VIN(vin).Year()
-
-	res, err := u.DeviceDefSvc.FindDeviceDefinitionByMMY(ctx, teslaMake, model, year)
+	// for Tesla, this does not call vendor to decode, uses same logic as below - advantage is it will create the DD if it doesn't exist
+	decodeVIN, err := u.DeviceDefSvc.DecodeVIN(ctx, vin, "", 0, "USA")
 	if err != nil {
 		return nil, err
 	}
 
-	return &decodeResult{ID: res.DeviceDefinitionId, Make: teslaMake, Model: model, Year: year}, nil
+	teslaMake := "Tesla"
+	model := shared.VIN(vin).TeslaModel()
+	// decode vin doesn't return Model, just the ID
+	return &decodeResult{ID: decodeVIN.DefinitionId, Make: teslaMake, Model: model, Year: int(decodeVIN.Year)}, nil
 }

--- a/internal/controllers/user_integrations_auth_controller_test.go
+++ b/internal/controllers/user_integrations_auth_controller_test.go
@@ -114,8 +114,16 @@ func (s *UserIntegrationAuthControllerTestSuite) TestCompleteOAuthExchanges() {
 	}, nil)
 	s.teslaFleetAPISvc.EXPECT().CompleteTeslaAuthCodeExchange(gomock.Any(), mockAuthCode, mockRedirectURI).Return(mockAuthCodeResp, nil)
 
-	s.deviceDefSvc.EXPECT().FindDeviceDefinitionByMMY(gomock.Any(), "Tesla", "Model 3", 2022).Return(&ddgrpc.GetDeviceDefinitionItemResponse{DeviceDefinitionId: "someID-1"}, nil)
-	s.deviceDefSvc.EXPECT().FindDeviceDefinitionByMMY(gomock.Any(), "Tesla", "Model Y", 2021).Return(&ddgrpc.GetDeviceDefinitionItemResponse{DeviceDefinitionId: "someID-2"}, nil)
+	s.deviceDefSvc.EXPECT().DecodeVIN(gomock.Any(), "5YJ3E1EB7NF145351", "", 0, "USA").Return(&ddgrpc.DecodeVinResponse{
+		Year:         2022,
+		Powertrain:   "BEV",
+		DefinitionId: "someID-1",
+	}, nil)
+	s.deviceDefSvc.EXPECT().DecodeVIN(gomock.Any(), "5YJYGDED4MF107402", "", 0, "USA").Return(&ddgrpc.DecodeVinResponse{
+		Year:         2021,
+		Powertrain:   "BEV",
+		DefinitionId: "someID-2",
+	}, nil)
 
 	s.credStore.EXPECT().Store(gomock.Any(), s.userAddr, &tmpcred.Credential{
 		IntegrationID: 2,


### PR DESCRIPTION
# Proposed Changes

main advantage of doing this is that the definition will get created if it doesn't exist

underlying logic in DD-api has been changed to not decode with a vendor but just use same logic as had here, so failure rate should be much lower. 

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->