### PR TITLE
Setting for blocking minting

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -114,6 +114,9 @@ type Settings struct {
 	IdentiyAPIURL url.URL `yaml:"IDENTITY_API_URL"`
 
 	ConnectionsReplacedIntegrations bool `yaml:"CONNECTIONS_REPLACED_INTEGRATIONS"`
+
+	// BlockMinting, if true, shuts off the synthetic minting endpoints
+	BlockMinting bool `yaml:"BLOCK_MINTING"`
 }
 
 func (s *Settings) IsProduction() bool {

--- a/internal/controllers/synthetic_devices_controller.go
+++ b/internal/controllers/synthetic_devices_controller.go
@@ -221,6 +221,10 @@ func (sdc *SyntheticDevicesController) MintSyntheticDevice(c *fiber.Ctx) error {
 	userDeviceID := c.Params("userDeviceID")
 	integrationID := c.Params("integrationID")
 
+	if sdc.Settings.BlockMinting {
+		return fiber.NewError(fiber.StatusInternalServerError, "Smartcar and Tesla device minting temporarily offline for a network upgrade.")
+	}
+
 	newIntegIDs, ok := utils.SyntheticIntegrationKSUIDToOtherIDs[integrationID]
 	if !ok {
 		return fiber.NewError(fiber.StatusBadRequest, "Cannot mint this integration with devices-api.")

--- a/internal/controllers/user_devices_controller.go
+++ b/internal/controllers/user_devices_controller.go
@@ -1338,6 +1338,10 @@ var erc1271magicValue = [4]byte{0x16, 0x26, 0xba, 0x7e}
 func (udc *UserDevicesController) PostMintDevice(c *fiber.Ctx) error {
 	userDeviceID := c.Params("userDeviceID")
 
+	if udc.Settings.BlockMinting {
+		return fiber.NewError(fiber.StatusInternalServerError, "Smartcar and Tesla device minting temporarily offline for a network upgrade.")
+	}
+
 	logger := helpers.GetLogger(c, udc.log)
 
 	tx, err := udc.DBS().Writer.BeginTx(c.Context(), &sql.TxOptions{Isolation: sql.LevelSerializable})


### PR DESCRIPTION
New boolean setting `BLOCK_MINTING`. Turns off

- `POST /v1/user/devices/{userDeviceId}/commands/mint`
- `POST /v1/user/devices/{userDeviceId}/integrations/{integrationId}/mint`